### PR TITLE
__WD_ConsoleWrite() NULL/Disable support

### DIFF
--- a/wd_core.au3
+++ b/wd_core.au3
@@ -1105,8 +1105,8 @@ Func _WD_Option($sOption, $vValue = Default)
 
 		Case "console"
 			If $vValue == "" Then Return $_WD_CONSOLE
-			If Not (IsString($vValue) Or IsInt($vValue) Or IsFunc($vValue)) Then
-				Return SetError(__WD_Error($sFuncName, $_WD_ERROR_InvalidDataType, "(string/int/function) $vValue: " & $vValue), 0, 0)
+			If Not (IsString($vValue) Or IsInt($vValue) Or IsFunc($vValue) Or $vValue == Null) Then
+				Return SetError(__WD_Error($sFuncName, $_WD_ERROR_InvalidDataType, "(string/int/function/null) $vValue: " & $vValue), 0, 0)
 			EndIf
 			$_WD_CONSOLE = $vValue
 
@@ -1725,6 +1725,8 @@ EndFunc   ;==>__WD_StripPath
 Func __WD_ConsoleWrite($sMsg)
 	If $_WD_CONSOLE = Default Then
 		ConsoleWrite($sMsg)
+	ElseIf $_WD_CONSOLE = Null Then
+		; do nothing
 	ElseIf IsFunc($_WD_CONSOLE) Then
 		Call($_WD_CONSOLE, $sMsg)
 	Else

--- a/wd_core.au3
+++ b/wd_core.au3
@@ -1106,7 +1106,7 @@ Func _WD_Option($sOption, $vValue = Default)
 		Case "console"
 			If $vValue == "" Then Return $_WD_CONSOLE
 			If Not (IsString($vValue) Or IsInt($vValue) Or IsFunc($vValue) Or $vValue == Null) Then
-				Return SetError(__WD_Error($sFuncName, $_WD_ERROR_InvalidDataType, "(string/int/function/null) $vValue: " & $vValue), 0, 0)
+				Return SetError(__WD_Error($sFuncName, $_WD_ERROR_InvalidDataType, "(default/function/int/null/string) $vValue: " & $vValue), 0, 0)
 			EndIf
 			$_WD_CONSOLE = $vValue
 

--- a/wd_core.au3
+++ b/wd_core.au3
@@ -157,7 +157,7 @@ Global $_WD_DRIVER_DETECT = True ; Don't launch new driver instance if one alrea
 Global $_WD_RESPONSE_TRIM = 100 ; Trim response string to given value for debug output
 Global $_WD_ERROR_MSGBOX = True ; Shows in compiled scripts error messages in msgboxes
 Global $_WD_DEBUG = $_WD_DEBUG_Info ; Trace to console and show web driver app
-Global $_WD_CONSOLE = Default ; Destination for console output
+Global $_WD_CONSOLE = ConsoleWrite ; Destination for console output
 Global $_WD_IFILTER = 16 ; Passed to _HtmlTableGetWriteToArray to control filtering
 Global $_WD_Sleep = Sleep ; Default to calling standard Sleep function
 Global $_WD_DefaultTimeout = 10000 ; 10 seconds
@@ -1105,8 +1105,8 @@ Func _WD_Option($sOption, $vValue = Default)
 
 		Case "console"
 			If $vValue == "" Then Return $_WD_CONSOLE
-			If Not (IsString($vValue) Or IsInt($vValue) Or IsFunc($vValue) Or $vValue == Null) Then
-				Return SetError(__WD_Error($sFuncName, $_WD_ERROR_InvalidDataType, "(default/function/int/null/string) $vValue: " & $vValue), 0, 0)
+			If Not (IsString($vValue) Or IsInt($vValue) Or IsFunc($vValue) Or $vValue = Null) Then
+				Return SetError(__WD_Error($sFuncName, $_WD_ERROR_InvalidDataType, "(func/int/null/string) $vValue: " & $vValue), 0, 0)
 			EndIf
 			$_WD_CONSOLE = $vValue
 
@@ -1723,12 +1723,10 @@ Func __WD_StripPath($sFilePath)
 EndFunc   ;==>__WD_StripPath
 
 Func __WD_ConsoleWrite($sMsg)
-	If $_WD_CONSOLE = Default Then
-		ConsoleWrite($sMsg)
+	If IsFunc($_WD_CONSOLE) Then
+		Call($_WD_CONSOLE, $sMsg)
 	ElseIf $_WD_CONSOLE = Null Then
 		; do nothing
-	ElseIf IsFunc($_WD_CONSOLE) Then
-		Call($_WD_CONSOLE, $sMsg)
 	Else
 		FileWrite($_WD_CONSOLE, $sMsg)
 	EndIf


### PR DESCRIPTION
## Pull request

### Proposed changes

`__WD_ConsoleWrite()` should support an easy way to disable any write to any output.

### Checklist

Put an `x` in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We are here to help!<br>
This is simply a reminder of what we are going to look for before merging your code.

- [X] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [X] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [ ] Bugfix (change which fixes an issue)
- [X] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?
Currently you can only use feature which sends data to some kind of output.
```autoit
Func __WD_ConsoleWrite($sMsg)
	If $_WD_CONSOLE = Default Then
		ConsoleWrite($sMsg)
	ElseIf IsFunc($_WD_CONSOLE) Then
		Call($_WD_CONSOLE, $sMsg)
	Else
		FileWrite($_WD_CONSOLE, $sMsg)
	EndIf
EndFunc   ;==>__WD_ConsoleWrite
```

### What is the new behavior?

You can easilly set NULL as output device

```AutoIt
	ElseIf $_WD_CONSOLE = Null Then
		; do nothing
```

by using:
```autoit
_WD_Option('console', Null)
```

### Additional context

This is normal behavior of various system to set output to NULL.

### System under test

NOT RELATED