### PR TITLE
_WD_UpdateDriver - fix for unpacking ".exe" file

### DIFF
--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -1414,12 +1414,17 @@ Func _WD_UpdateDriver($sBrowser, $sInstallDir = Default, $bFlag64 = Default, $bF
 							Else
 								; delete webdriver from disk before unpacking to avoid potential problems
 								FileDelete($sInstallDir & $sDriverEXE)
+								Local $bEXEWasFound = False
 								For $FileItem In $FilesInZip ; Check the files in the archive separately
-									If StringRight($FileItem.Name, 4) = ".exe" Then ; extract only EXE files
+									; https://docs.microsoft.com/pl-pl/windows/win32/shell/folder
+									; https://docs.microsoft.com/pl-pl/windows/win32/shell/folder-items
+									; https://docs.microsoft.com/pl-pl/windows/win32/shell/folderitem
+									If StringRight($FileItem.Name, 4) = ".exe" Or StringRight($FileItem.Path, 4) = ".exe" Then ; extract only EXE files
+										$bEXEWasFound = True
 										$oShell.NameSpace($sInstallDir).CopyHere($FileItem, 20) ; 20 = (4) Do not display a progress dialog box. + (16) Respond with "Yes to All" for any dialog box that is displayed.
 									EndIf
 								Next
-								If @error Then
+								If @error Or Not $bEXEWasFound Then
 									$iErr = $_WD_ERROR_GeneralError
 								Else
 									$iErr = $_WD_ERROR_Success


### PR DESCRIPTION
https://www.autoitscript.com/forum/topic/205553-webdriver-udf-help-support-iii/?do=findComment&comment=1497208

## Pull request

### Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.<br>
Please ensure you have read and noticed the checklist below.

### Checklist

Put an `x` in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We are here to help!<br>
This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [x] Bugfix (change which fixes an issue)
- [ ] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

Please describe the current behavior that you are modifying, or link to a relevant issue.
On some Windows installations, the WebDriver EXE file does not unpack.

### What is the new behavior?

Unpack EXE in such cases.

### Additional context

Add any other context about the problem here.
https://www.autoitscript.com/forum/topic/205553-webdriver-udf-help-support-iii/?do=findComment&comment=1497208

The main issue was here:
```autoit
For $FileItem In $FilesInZip ; Check the files in the archive separately
	; https://docs.microsoft.com/pl-pl/windows/win32/shell/folder
	; https://docs.microsoft.com/pl-pl/windows/win32/shell/folder-items
	; https://docs.microsoft.com/pl-pl/windows/win32/shell/folderitem
	If StringRight($FileItem.Name, 4) = ".exe" Or StringRight($FileItem.Path, 4) = ".exe" Then ; extract only EXE files
		$bEXEWasFound = True
		$oShell.NameSpace($sInstallDir).CopyHere($FileItem, 20) ; 20 = (4) Do not display a progress dialog box. + (16) Respond with "Yes to All" for any dialog box that is displayed.
	EndIf
Next
```
The reson was that on some system $FileItem.Name returns only name without extension.
`If StringRight($FileItem.Name, 4) = ".exe" Then ; extract only EXE files`

Solution was to check also: $FileItem.Path
`If StringRight($FileItem.Name, 4) = ".exe" Or StringRight($FileItem.Path, 4) = ".exe" Then ; extract only EXE files`

also added some additionall checking `$bEXEWasFound`

### System under test

Please complete the following information.

- OS: Windows 10 Pro 64Bit Windows Feature Experience Pack 120.2212.4170.0
- OS Arch.: X64
- Browser: tested on chrome, but this issue was not related to any browser
