### PR TITLE
__WD_ConsoleWrite : preserve @error and @extended

### DIFF
--- a/wd_core.au3
+++ b/wd_core.au3
@@ -1724,7 +1724,7 @@ Func __WD_StripPath($sFilePath)
 	Return StringRegExpReplace($sFilePath, "^.*\\(.*)$", "$1")
 EndFunc   ;==>__WD_StripPath
 
-Func __WD_ConsoleWrite($sMsg)
+Func __WD_ConsoleWrite($sMsg, $iError = @error, $iExtended = @extended)
 	If IsFunc($_WD_CONSOLE) Then
 		Call($_WD_CONSOLE, $sMsg)
 	ElseIf $_WD_CONSOLE = Null Then
@@ -1732,6 +1732,7 @@ Func __WD_ConsoleWrite($sMsg)
 	Else
 		FileWrite($_WD_CONSOLE, $sMsg)
 	EndIf
+	Return SetError($iError, $iExtended)
 EndFunc   ;==>__WD_ConsoleWrite
 
 ; #INTERNAL_USE_ONLY# ===========================================================================================================


### PR DESCRIPTION
## Pull request

### Proposed changes

__WD_ConsoleWrite should preserve @error and @extended

### Checklist

Put an `x` in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We are here to help!<br>
This is simply a reminder of what we are going to look for before merging your code.

- [ ] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [ ] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [ ] Bugfix (change which fixes an issue)
- [ ] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

__WD_ConsoleWrite dosen't preserve @error and @extended

### What is the new behavior?

__WD_ConsoleWrite preserve @error and @extended

### Additional context

https://github.com/Danp2/au3WebDriver/issues/219

### System under test

Please complete the following information.

not related