### PR TITLE
OPERA: _WD_GetBrowserVersion refactoring

### DIFF
--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -1429,8 +1429,11 @@ Func _WD_GetBrowserVersion($sBrowser)
 	Local $iErr = $_WD_ERROR_Success, $iExt = 0
 	Local $sBrowserVersion = "0"
 
-	If FileExists($sBrowser) Then
-		If _WinAPI_GetBinaryType($sBrowser) = 0 Then
+	If StringInStr($sBrowser,'\') Then
+		If FileExists($sBrowser) = 0 Then
+			$iErr = $_WD_ERROR_FileIssue
+			$iExt = 21
+		ElseIf _WinAPI_GetBinaryType($sBrowser) = 0 Then
 			$iErr = $_WD_ERROR_FileIssue
 			$iExt = 22
 		Else

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -1430,18 +1430,23 @@ Func _WD_GetBrowserVersion($sBrowser)
 	Local $sBrowserVersion = "0"
 
 	If FileExists($sBrowser) Then
-		; Directly retrieve file version if full path was supplied
-		$sBrowserVersion = FileGetVersion($sBrowser)
-		If @error Then
+		If _WinAPI_GetBinaryType($sBrowser) = 0 Then
 			$iErr = $_WD_ERROR_FileIssue
-			$iExt = 21
+			$iExt = 22
 		Else
-			; Extract filename and confirm match in list of supported browsers
-			$sBrowser = StringRegExpReplace($sBrowser, "^.*\\|\..*$", "")
-			_ArraySearch($_WD_SupportedBrowsers, $sBrowser, Default, Default, Default, Default, Default, $_WD_BROWSER_Name)
+			; Directly retrieve file version if full path was supplied
+			$sBrowserVersion = FileGetVersion($sBrowser)
 			If @error Then
-				# CONSIDER to add new $_WD_ERROR_NotSupported
-				$iErr = $_WD_ERROR_NotFound
+				$iErr = $_WD_ERROR_FileIssue
+				$iExt = 23
+			Else
+				; Extract filename and confirm match in list of supported browsers
+				$sBrowser = StringRegExpReplace($sBrowser, "^.*\\|\..*$", "")
+				_ArraySearch($_WD_SupportedBrowsers, $sBrowser, Default, Default, Default, Default, Default, $_WD_BROWSER_Name)
+				If @error Then
+					# CONSIDER to add new $_WD_ERROR_NotSupported
+					$iErr = $_WD_ERROR_NotFound
+				EndIf
 			EndIf
 		EndIf
 	Else
@@ -1450,12 +1455,17 @@ Func _WD_GetBrowserVersion($sBrowser)
 			$iErr = @error
 		ElseIf Not FileExists($sPath) Then
 			$iErr = $_WD_ERROR_FileIssue
-			$iExt = 22
+			$iExt = 24
 		Else
-			$sBrowserVersion = FileGetVersion($sPath)
-			If @error Then
+			If _WinAPI_GetBinaryType($sPath) = 0 Then
 				$iErr = $_WD_ERROR_FileIssue
-				$iExt = 23
+				$iExt = 25
+			Else
+				$sBrowserVersion = FileGetVersion($sPath)
+				If @error Then
+					$iErr = $_WD_ERROR_FileIssue
+					$iExt = 26
+				EndIf
 			EndIf
 		EndIf
 	EndIf

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -1429,7 +1429,7 @@ Func _WD_GetBrowserVersion($sBrowser)
 	Local $iErr = $_WD_ERROR_Success, $iExt = 0
 	Local $sBrowserVersion = "0"
 
-	If StringInStr($sBrowser,'\') Then
+	If StringInStr($sBrowser, '\') Then
 		If FileExists($sBrowser) = 0 Then
 			$iErr = $_WD_ERROR_FileIssue
 			$iExt = 21
@@ -1456,7 +1456,7 @@ Func _WD_GetBrowserVersion($sBrowser)
 		Local $sPath = _WD_GetBrowserPath($sBrowser)
 		If @error Then
 			$iErr = @error
-		ElseIf Not FileExists($sPath) Then
+		ElseIf FileExists($sPath) = 0 Then
 			$iErr = $_WD_ERROR_FileIssue
 			$iExt = 24
 		Else

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -1456,18 +1456,19 @@ Func _WD_GetBrowserVersion($sBrowser)
 		Local $sPath = _WD_GetBrowserPath($sBrowser)
 		If @error Then
 			$iErr = @error
+			$iExt = 24
 		ElseIf FileExists($sPath) = 0 Then
 			$iErr = $_WD_ERROR_FileIssue
-			$iExt = 24
+			$iExt = 25
 		Else
 			If _WinAPI_GetBinaryType($sPath) = 0 Then
 				$iErr = $_WD_ERROR_FileIssue
-				$iExt = 25
+				$iExt = 26
 			Else
 				$sBrowserVersion = FileGetVersion($sPath)
 				If @error Then
 					$iErr = $_WD_ERROR_FileIssue
-					$iExt = 26
+					$iExt = 27
 				EndIf
 			EndIf
 		EndIf


### PR DESCRIPTION
## Pull request

### Proposed changes

For me it is resonable/more rational that `If FileExists($sBrowser) Then` is checked first.
I know that this will be not comonly used case (file checking instead registry checking) but this function is used once per script run and there is nothing to do with performance, only with code clarity and error handling.
Thus I also added few `$_WD_ERROR_FileIssue` and `$iExt` and also I propose to add `$_WD_ERROR_NotSupported`


### Checklist

Put an `x` in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We are here to help!<br>
This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [ ] Bugfix (change which fixes an issue)
- [ ] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

Not optimal code (in my opinin).

### What is the new behavior?

Better code clarity , and better error handling

### Additional context

NONE

### System under test

NOT RELATED