### PR TITLE
OPERA:  _WD_GetBrowserVersion/Path refactoring

### DIFF
--- a/wd_core.au3
+++ b/wd_core.au3
@@ -107,6 +107,7 @@ Global Enum _
 		$_WD_ERROR_UnknownCommand, _ ;
 		$_WD_ERROR_UserAbort, _ ;
 		$_WD_ERROR_FileIssue, _ ;
+		$_WD_ERROR_NotSupported, _ ;
 		$_WD_ERROR_COUNTER ;
 
 Global Enum _
@@ -139,7 +140,8 @@ Global Const $aWD_ERROR_DESC[$_WD_ERROR_COUNTER] = [ _
 		"Invalid session ID", _
 		"Unknown Command", _
 		"User Aborted", _
-		"File issue" _
+		"File issue", _
+		"Browser or feature not supported" _
 		]
 
 Global Const $WD_ErrorInvalidSession = "invalid session id"

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -1302,15 +1302,15 @@ Func _WD_UpdateDriver($sBrowser, $sInstallDir = Default, $bFlag64 = Default, $bF
 
 		$sBrowserVersion = _WD_GetBrowserVersion($sBrowser)
 		$iErr = @error
+		Local $iIndex = @extended
 
 		If $iErr = $_WD_ERROR_Success Then
-			If StringInStr($sBrowser, '\') Then 
-				; Extract filename from full path
+			If StringInStr($sBrowser, '\') Then
+				; Extract filename from full path - for any case
 				$sBrowser = StringRegExpReplace($sBrowser, "^.*\\|\..*$", "")
 			EndIf
 
-			; Match in list of supported browsers
-			Local $iIndex = _ArraySearch($_WD_SupportedBrowsers, $sBrowser, Default, Default, Default, Default, Default, $_WD_BROWSER_Name)
+			; Match exe file name in list of supported browsers
 			$sDriverEXE = $_WD_SupportedBrowsers[$iIndex][$_WD_BROWSER_DriverName]
 
 			; Determine current local webdriver Architecture

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -1438,10 +1438,9 @@ Func _WD_GetBrowserVersion($sBrowser)
 	Local $sBrowserVersion = "0"
 
 	Local $sPath = _WD_GetBrowserPath($sBrowser)
+	$iErr = @error
+	$iExt = @extended
 	If @error Then
-		$iErr = @error
-		$iExt = @extended
-
 		; as registry checks fails, now checking if file exist and is exeutable
 		If FileExists($sBrowser) Then
 			If _WinAPI_GetBinaryType($sBrowser) = 0 Then
@@ -1454,9 +1453,11 @@ Func _WD_GetBrowserVersion($sBrowser)
 
 				; Extract filename and confirm match in list of supported browsers
 				$sBrowser = StringRegExpReplace($sBrowser, "^.*\\|\..*$", "")
-				If _ArraySearch($_WD_SupportedBrowsers, $sBrowser, Default, Default, Default, Default, Default, $_WD_BROWSER_Name) = -1 Then
+				Local $iIndex = _ArraySearch($_WD_SupportedBrowsers, $sBrowser, Default, Default, Default, Default, Default, $_WD_BROWSER_Name)
+				If $iIndex = -1 Then
 					$iErr = $_WD_ERROR_NotSupported
 				Else
+					$iExt = $iIndex
 					$sPath = $sBrowser
 				EndIf
 			EndIf
@@ -1523,6 +1524,8 @@ Func _WD_GetBrowserPath($sBrowser)
 			ElseIf _WinAPI_GetBinaryType($sPath) = 0 Then
 				$iErr = $_WD_ERROR_FileIssue
 				$iExt = 24
+			Else
+				$iExt = $iIndex
 			EndIf
 		EndIf
 	EndIf

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -1266,6 +1266,7 @@ EndFunc   ;==>_WD_IsLatestRelease
 ;                  - $_WD_ERROR_NotFound
 ;                  - $_WD_ERROR_FileIssue
 ;                  - $_WD_ERROR_UserAbort
+;                  - $_WD_ERROR_NotSupported
 ; Author ........: Danp2, CyCho
 ; Modified ......: mLipok
 ; Remarks .......: When $bForce = Null, then the function will check for an updated webdriver without actually performing the update.
@@ -1481,6 +1482,7 @@ EndFunc   ;==>_WD_GetBrowserVersion
 ; Return values .: Success - Full path to browser executable
 ;                  Failure - "" and sets @error to one of the following values:
 ;                  - $_WD_ERROR_InvalidValue
+;                  - $_WD_ERROR_NotSupported
 ;                  - $_WD_ERROR_NotFound
 ; Author ........: Danp2
 ; Modified ......: mLipok

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -1305,11 +1305,6 @@ Func _WD_UpdateDriver($sBrowser, $sInstallDir = Default, $bFlag64 = Default, $bF
 		Local $iIndex = @extended
 
 		If $iErr = $_WD_ERROR_Success Then
-			If StringInStr($sBrowser, '\') Then
-				; Extract filename from full path - for any case
-				$sBrowser = StringRegExpReplace($sBrowser, "^.*\\|\..*$", "")
-			EndIf
-
 			; Match exe file name in list of supported browsers
 			$sDriverEXE = $_WD_SupportedBrowsers[$iIndex][$_WD_BROWSER_DriverName]
 

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -1443,32 +1443,32 @@ Func _WD_GetBrowserVersion($sBrowser)
 	If @error Then
 		; as registry checks fails, now checking if file exist and is exeutable
 		If FileExists($sBrowser) Then
-			If _WinAPI_GetBinaryType($sBrowser) = 0 Then
-				$iErr = $_WD_ERROR_FileIssue
-				$iExt = 31 ; $iExt from 31 to 39 are related to _WD_GetBrowserVersion()
-			Else
-				; Reseting as we are now checking file instead registry entries
-				$iErr = $_WD_ERROR_Success
-				$iExt = 0
+			; Reseting as we are now checking file instead registry entries
+			$iErr = $_WD_ERROR_Success
+			$iExt = 0
 
-				; Extract filename and confirm match in list of supported browsers
-				$sBrowser = StringRegExpReplace($sBrowser, "^.*\\|\..*$", "")
-				Local $iIndex = _ArraySearch($_WD_SupportedBrowsers, $sBrowser, Default, Default, Default, Default, Default, $_WD_BROWSER_Name)
-				If $iIndex = -1 Then
-					$iErr = $_WD_ERROR_NotSupported
-				Else
-					$iExt = $iIndex
-					$sPath = $sBrowser
-				EndIf
+			; Extract filename and confirm match in list of supported browsers
+			$sBrowser = StringRegExpReplace($sBrowser, "^.*\\|\..*$", "")
+			Local $iIndex = _ArraySearch($_WD_SupportedBrowsers, $sBrowser, Default, Default, Default, Default, Default, $_WD_BROWSER_Name)
+			If @error Then
+				$iErr = $_WD_ERROR_NotSupported
+			Else
+				$iExt = $iIndex
+				$sPath = $sBrowser
 			EndIf
 		EndIf
 	EndIf
 
 	If $iErr = $_WD_ERROR_Success Then
-		$sBrowserVersion = FileGetVersion($sPath)
-		If @error Then
+		If _WinAPI_GetBinaryType($sPath) = 0 Then
 			$iErr = $_WD_ERROR_FileIssue
-			$iExt = 32
+			$iExt = 31 ; $iExt from 31 to 39 are related to _WD_GetBrowserVersion()
+		Else
+			$sBrowserVersion = FileGetVersion($sPath)
+			If @error Then
+				$iErr = $_WD_ERROR_FileIssue
+				$iExt = 32
+			EndIf
 		EndIf
 	EndIf
 
@@ -1517,16 +1517,7 @@ Func _WD_GetBrowserPath($sBrowser)
 		Else
 			$sPath = StringRegExpReplace($sPath, '["'']', '') ; Remove quotation marks
 			$sPath = StringRegExpReplace($sPath, '(.+\\)(.*exe)', '$1' & $sEXE) ; Registry entries can contain "Launcher.exe" instead "opera.exe"
-
-			If FileExists($sPath) = 0 Then
-				$iErr = $_WD_ERROR_FileIssue
-				$iExt = 23
-			ElseIf _WinAPI_GetBinaryType($sPath) = 0 Then
-				$iErr = $_WD_ERROR_FileIssue
-				$iExt = 24
-			Else
-				$iExt = $iIndex
-			EndIf
+			$iExt = $iIndex
 		EndIf
 	EndIf
 	Return SetError(__WD_Error($sFuncName, $iErr), $iExt, $sPath)

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -1441,7 +1441,7 @@ Func _WD_GetBrowserVersion($sBrowser)
 	$iErr = @error
 	$iExt = @extended
 	If @error Then
-		; as registry checks fails, now checking if file exist and is exeutable
+		; as registry checks fails, now checking if file exist
 		If FileExists($sBrowser) Then
 			; Reseting as we are now checking file instead registry entries
 			$iErr = $_WD_ERROR_Success
@@ -1460,7 +1460,7 @@ Func _WD_GetBrowserVersion($sBrowser)
 	EndIf
 
 	If $iErr = $_WD_ERROR_Success Then
-		If _WinAPI_GetBinaryType($sPath) = 0 Then
+		If _WinAPI_GetBinaryType($sPath) = 0 Then ; check if file is exeutable
 			$iErr = $_WD_ERROR_FileIssue
 			$iExt = 31 ; $iExt from 31 to 39 are related to _WD_GetBrowserVersion()
 		Else

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -1460,7 +1460,7 @@ Func _WD_GetBrowserVersion($sBrowser)
 	EndIf
 
 	If $iErr = $_WD_ERROR_Success Then
-		If _WinAPI_GetBinaryType($sPath) = 0 Then ; check if file is exeutable
+		If _WinAPI_GetBinaryType($sPath) = 0 Then ; check if file is executable
 			$iErr = $_WD_ERROR_FileIssue
 			$iExt = 31 ; $iExt from 31 to 39 are related to _WD_GetBrowserVersion()
 		Else


### PR DESCRIPTION
## Pull request

### Proposed changes

I have added more error handling and fixed `_WD_UpdateDriver` in case when file full path is used `Extract filename from full path`

```AutoIt
		If $iErr = $_WD_ERROR_Success Then
			If StringInStr($sBrowser, '\') Then
				; Extract filename from full path
				$sBrowser = StringRegExpReplace($sBrowser, "^.*\\|\..*$", "")
			EndIf

			; Match in list of supported browsers
			Local $iIndex = _ArraySearch($_WD_SupportedBrowsers, $sBrowser, Default, Default, Default, Default, Default, $_WD_BROWSER_Name)
			$sDriverEXE = $_WD_SupportedBrowsers[$iIndex][$_WD_BROWSER_DriverName]
```

### Checklist

Put an `x` in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We are here to help!<br>
This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [x] Bugfix (change which fixes an issue)
- [x] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

Error handling is not complete.
`_WD_UpdateDriver` may fail in case when file full path is used


### What is the new behavior?

better error handling and fixed `_WD_UpdateDriver` in case when file full path is used

### Additional context

https://github.com/Danp2/au3WebDriver/pull/234


### System under test

NOT RELATED