### PR TITLE
wd_capabilites: validate result of Initialization

### DIFF
--- a/wd_capabilities.au3
+++ b/wd_capabilities.au3
@@ -169,9 +169,12 @@ Func _WD_CapabilitiesAdd($key, $value1 = '', $value2 = '')
 	If $value1 = Default Then $value1 = 'default'
 	If $value2 = Default Then $value2 = 'default'
 	If StringInStr('alwaysMatch|firstMatch', $key) Then
-		$_WD_CAPS__CURRENTIDX = __WD_CapabilitiesInitialize($key, $value1)
+		Local $iResult = __WD_CapabilitiesInitialize($key, $value1)
+		If Not @error Then $_WD_CAPS__CURRENTIDX = $iResult
 		Return SetError(@error, @extended, $_WD_CAPS__CURRENTIDX)
 	EndIf
+	If $_WD_CAPS__CURRENTIDX = -1 Then Return SetError(1) ; must be properly initialized
+
 	#TODO use $value2 for "noProxy"  https://www.w3.org/TR/webdriver/#dfn-page-load-strategy
 	Local $s_Notation = ''
 	If $key = 'excludeSwitches' Then ; for adding "excludeSwitches" capability in specific/vendor capabilities : ........
@@ -271,30 +274,29 @@ EndFunc   ;==>_WD_CapabilitiesGet
 ; ===============================================================================================================================
 Func __WD_CapabilitiesInitialize($s_MatchType, $s_BrowserName = '') ; $s_MatchType = 'alwaysMatch' Or 'firstMatch'
 	#Region - parameters validation
-;~ 	__WD_ConsoleWrite("! @ScriptLineNumber = " & @ScriptLineNumber)
 	If Not StringInStr('alwaysMatch|firstMatch', $s_MatchType) Then _
 			Return SetError(1)
-;~ 	__WD_ConsoleWrite("! @ScriptLineNumber = " & @ScriptLineNumber)
 
-;~ 	MsgBox($MB_OK + $MB_TOPMOST + $MB_ICONINFORMATION, "Information #" & @ScriptLineNumber, "$s_BrowserName = " & $s_BrowserName & @CRLF & "$s_MatchType = " & $s_MatchType)
 	Local $s_SpecificOptions_KeyName = ''
 
 	If $s_BrowserName <> '' Then
 		Local $iIndex = _ArraySearch($_WD_SupportedBrowsers, StringLower($s_BrowserName), Default, Default, Default, Default, Default, $_WD_BROWSER_Name)
+		If @error Then
+			Return SetError(2) ; $_WD_ERROR_NotSupported
+		EndIf
 		$s_SpecificOptions_KeyName = $_WD_SupportedBrowsers[$iIndex][$_WD_BROWSER_OptionsKey]
 	ElseIf $s_MatchType = 'alwaysMatch' And $s_BrowserName = '' Then
 		$s_SpecificOptions_KeyName = ''
 	ElseIf $s_MatchType = 'firstMatch' And $s_BrowserName = '' Then
-		Return SetError(2)
+		Return SetError(3)
 ;~ 	Else
-;~ 		Return SetError(3) ; this should be tested/reviewed later (@mLipok 23-02-2022)
+;~ 		Return SetError(4) ; this should be tested/reviewed later (@mLipok 23-02-2022)
 	EndIf
 	#EndRegion - parameters validation
 
 	#Region - reindexing API
 	Local $i_API_Recent_Size = UBound($_WD_CAPS__API), $i_API_New_Size = $i_API_Recent_Size + 1, $i_API_New_IDX = $i_API_New_Size - 1
 	ReDim $_WD_CAPS__API[$i_API_New_Size][$_WD_CAPS__COUNTER]
-	__WD_ConsoleWrite("! @ScriptLineNumber = " & @ScriptLineNumber)
 	#EndRegion - reindexing API
 
 	#Region - new "MATCH" Initialization
@@ -315,7 +317,6 @@ Func __WD_CapabilitiesInitialize($s_MatchType, $s_BrowserName = '') ; $s_MatchTy
 	$_WD_CAPS__API[$i_API_New_IDX][$_WD_CAPS__SPECIFICVENDOR__EXCSWITCH] = -1 ; used for indexing ......  "excludeSwitches" : [JSON ARRRAY]
 	$_WD_CAPS__CURRENTIDX = $i_API_New_IDX ; set last API IDX as CURRENT API IDX
 	#EndRegion - new "MATCH" Initialization
-;~ 	__WD_ConsoleWrite("! @ScriptLineNumber = " & @ScriptLineNumber)
 	Return $_WD_CAPS__CURRENTIDX ; return current API IDX
 
 	#Region - FOR TESTING ONLY


### PR DESCRIPTION
## Pull request

### Proposed changes

When user pass wrong browser name which was reported in:  [__WD_CapabilitiesInitialize: Needs to validate result of _ArraySearch](https://github.com/Danp2/au3WebDriver/issues/250)
or initialization was not performed at first place functions 
.... then function should return error and not set capabilites JSON string.


### Checklist

Put an `x` in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We are here to help!<br>
This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [x] Bugfix (change which fixes an issue)
- [x] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

Take a look here: [__WD_CapabilitiesInitialize: Needs to validate result of _ArraySearch](https://github.com/Danp2/au3WebDriver/issues/250)

### What is the new behavior?

Fixed. Function returns error and not setting any capabilities JSON string.

### Additional context
[__WD_CapabilitiesInitialize: Needs to validate result of _ArraySearch](https://github.com/Danp2/au3WebDriver/issues/250)

### System under test

Not releated