### PR TITLE
demo: Refactoring

### DIFF
--- a/wd_demo.au3
+++ b/wd_demo.au3
@@ -7,6 +7,7 @@
 #include <GuiComboBoxEx.au3>
 #include <GUIConstantsEx.au3>
 #include <WindowsConstants.au3>
+
 ; non standard UDF's
 #include "wd_helper.au3"
 #include "wd_capabilities.au3"
@@ -222,7 +223,7 @@ Func _RunDemo_Update($idUpdate, $sBrowserName)
 	If $sUpdate = 'Report only' Then $bForce = Null
 
 	Local $bUpdateResult = _WD_UpdateDriver($sBrowserName, @ScriptDir, $bFlag64, $bForce)
-	ConsoleWrite('$bUpdateResult = ' & $bUpdateResult & @CRLF)
+	ConsoleWrite('> UpdateResult = ' & $bUpdateResult & @CRLF)
 EndFunc   ;==>_RunDemo_Update
 
 Func _RunDemo_Headless($idHeadless)
@@ -316,20 +317,20 @@ EndFunc   ;==>DemoTimeouts
 
 Func DemoNavigation()
 	_WD_Navigate($sSession, "http://google.com")
-	ConsoleWrite("URL=" & _WD_Action($sSession, 'url') & @CRLF)
+	ConsoleWrite("> URL=" & _WD_Action($sSession, 'url') & @CRLF)
 
 	_WD_NewTab($sSession, Default, Default, "http://yahoo.com")
-	ConsoleWrite("URL=" & _WD_Action($sSession, 'url') & @CRLF)
+	ConsoleWrite("> URL=" & _WD_Action($sSession, 'url') & @CRLF)
 
 	;	_WD_Navigate($sSession, "http://yahoo.com")
 	_WD_NewTab($sSession, True, Default, 'http://bing.com', 'width=200,height=200')
-	ConsoleWrite("URL=" & _WD_Action($sSession, 'url') & @CRLF)
+	ConsoleWrite("> URL=" & _WD_Action($sSession, 'url') & @CRLF)
 
 	_WD_Attach($sSession, "google.com", "URL")
-	ConsoleWrite("URL=" & _WD_Action($sSession, 'url') & @CRLF)
+	ConsoleWrite("> URL=" & _WD_Action($sSession, 'url') & @CRLF)
 
 	_WD_Attach($sSession, "yahoo.com", "URL")
-	ConsoleWrite("URL=" & _WD_Action($sSession, 'url') & @CRLF)
+	ConsoleWrite("> URL=" & _WD_Action($sSession, 'url') & @CRLF)
 
 EndFunc   ;==>DemoNavigation
 


### PR DESCRIPTION
## Pull request

### Proposed changes

Setting Debug to none should shown less info in console.
I notice that each console with "none" should comes only from demo and should differ from messages from UDF.
Thus I added "> " to consolewrite

### Checklist

Put an `x` in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We are here to help!<br>
This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [ ] Bugfix (change which fixes an issue)
- [ ] Feature (change which adds functionality)
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [x] Other (description in "Proposed changes")

### What is the current behavior?

demo console messages **it does not** differ from UDF messages.

### What is the new behavior?

demo console messages differ from UDF messages.

### Additional context

It makes easier to use wd_demo.au3 for checking if UDF works fine after each new changes, when messages from wd_demo.au3 differ form messages form UDF

### System under test

NOT RELATED