### PR TITLE
_WD_CapabilitiesDump relates on $_WD_DEBUG

### DIFF
--- a/wd_capabilities.au3
+++ b/wd_capabilities.au3
@@ -424,15 +424,17 @@ EndFunc   ;==>__WD_CapabilitiesNotation
 ; ===============================================================================================================================
 Func _WD_CapabilitiesDump($s_Comment)
 	If @Compiled Then Return ; because of GDRP reason do not throw nothing to console when compiled script
-	__WD_ConsoleWrite('! _WD_Capabilities: API START: ' & $s_Comment)
-	__WD_ConsoleWrite("- $_WD_CAPS__API: Rows= " & UBound($_WD_CAPS__API, 1))
-	__WD_ConsoleWrite("- $_WD_CAPS__API: Cols= " & UBound($_WD_CAPS__API, 2))
-	__WD_ConsoleWrite(_ArrayToString($_WD_CAPS__API))
-	__WD_ConsoleWrite('! _WD_Capabilities: API END: ' & $s_Comment)
+	If $_WD_DEBUG <> $_WD_DEBUG_None Then
+		__WD_ConsoleWrite('! _WD_Capabilities: API START: ' & $s_Comment)
+		__WD_ConsoleWrite("- $_WD_CAPS__API: Rows= " & UBound($_WD_CAPS__API, 1))
+		__WD_ConsoleWrite("- $_WD_CAPS__API: Cols= " & UBound($_WD_CAPS__API, 2))
+		__WD_ConsoleWrite(_ArrayToString($_WD_CAPS__API))
+		__WD_ConsoleWrite('! _WD_Capabilities: API END: ' & $s_Comment)
 
-	__WD_ConsoleWrite('! _WD_Capabilities: JSON START: ' & $s_Comment)
-	__WD_ConsoleWrite(_WD_CapabilitiesGet())
-	__WD_ConsoleWrite('! _WD_Capabilities: JSON END: ' & $s_Comment)
+		__WD_ConsoleWrite('! _WD_Capabilities: JSON START: ' & $s_Comment)
+		__WD_ConsoleWrite(_WD_CapabilitiesGet())
+		__WD_ConsoleWrite('! _WD_Capabilities: JSON END: ' & $s_Comment)
+	EndIf
 EndFunc   ;==>_WD_CapabilitiesDump
 
 ; #FUNCTION# ====================================================================================================================


### PR DESCRIPTION
## Pull request

### Proposed changes

$_WD_DEBUG it should be considered specifically when it is = $_WD_DEBUG_None

### Checklist

Put an `x` in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We are here to help!<br>
This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [ ] Bugfix (change which fixes an issue)
- [ ] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [x] Other (look on "Proposed changes")

### What is the current behavior?

Please describe the current behavior that you are modifying, or link to a relevant issue.

### What is the new behavior?

messages are sent to console even when $_WD_DEBUG = $_WD_DEBUG_None

### Additional context

$_WD_DEBUG = $_WD_DEBUG_None is checked

### System under test

not related