### PR TITLE
_WD_GetBrowserVersion() fixing check BinaryType

### DIFF
--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -1531,8 +1531,8 @@ Func _WD_GetBrowserVersion($sBrowser)
 			$iExt = 0
 
 			; Extract filename and confirm match in list of supported browsers
-			$sBrowser = StringRegExpReplace($sBrowser, "^.*\\|\..*$", "")
-			Local $iIndex = _ArraySearch($_WD_SupportedBrowsers, $sBrowser, Default, Default, Default, Default, Default, $_WD_BROWSER_Name)
+			Local $sBrowserName = StringRegExpReplace($sBrowser, "^.*\\|\..*$", "")
+			Local $iIndex = _ArraySearch($_WD_SupportedBrowsers, $sBrowserName, Default, Default, Default, Default, Default, $_WD_BROWSER_Name)
 			If @error Then
 				$iErr = $_WD_ERROR_NotSupported
 			Else


### PR DESCRIPTION
## Pull request

### Proposed changes

### Checklist

Put an `x` in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We are here to help!<br>
This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [x] Bugfix (change which fixes an issue)
- [ ] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

after `If FileExists($sBrowser) Then` 
`$sBrowser` cant be changed from `FileFullPath` to `FileName`  because in next few lines `$sPath = $sBrowser` and then this following part
```autoit
		If _WinAPI_GetBinaryType($sPath) = 0 Then ; check if file is executable
			$iErr = $_WD_ERROR_FileIssue
			$iExt = 31
		Else
```
set Error and Extended, and this is all because `FielFullPath` is changed to `FileName`

### What is the new behavior?

`$sBrowser` is not changed and `_WinAPI_GetBinaryType($sPath)` returns proper results

### Additional context

None

### System under test

Not related
