### PR TITLE
_WD_CapabilitiesAdd : debuggerAddress

### DIFF
--- a/wd_capabilities.au3
+++ b/wd_capabilities.au3
@@ -150,8 +150,10 @@ EndFunc   ;==>_WD_CapabilitiesStartup
 ;                               | 'proxy'
 ;                               | 'w3c'
 ;                               | 'binary'
+;                               | 'debuggerAddress'
 ;                               | 'args'
 ;                               | 'logs'
+;                               | 'maxInstances'
 ;                               | 'prefs'
 ;                               | 'env'
 ;                               | '' an empty string
@@ -194,7 +196,7 @@ Func _WD_CapabilitiesAdd($key, $value1 = '', $value2 = '')
 		EndIf
 		__WD_CapabilitiesSwitch($key, $value1, $value2)          ; as the notation was modified now parameters should be switched
 ;~ 		If Not @Compiled Then __WD_ConsoleWrite("- IFNC: " & @ScriptLineNumber & ' $s_Notation =' & $s_Notation)
-	ElseIf $key = 'w3c' Or $key = 'maxInstances' Or $key = 'binary' Then  ; for adding capability in specific/vendor capabilities for example: goog:chromeOptions
+	ElseIf $key = 'w3c' Or $key = 'maxInstances' Or $key = 'binary' Or $key = 'debuggerAddress' Then  ; for adding capability in specific/vendor capabilities for example: goog:chromeOptions
 ;~ 		https://sites.google.com/a/chromium.org/chromedriver/capabilities#TOC-Recognized-capabilities
 		$s_Notation = __WD_CapabilitiesNotation($_WD_CAPS__SPECIFICVENDOR__OPTS)
 		$s_Notation &= '[' & $key & ']'


### PR DESCRIPTION
## Pull request

### Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.<br>
Please ensure you have read and noticed the checklist below.

### Checklist

Put an `x` in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We are here to help!<br>
This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [ ] Bugfix (change which fixes an issue)
- [x] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

Lack of support for `debuggerAddress`

### What is the new behavior?

Added supprot for `debuggerAddress`
```autoit
_WD_CapabilitiesAdd('firstMatch', 'chrome')
_WD_CapabilitiesAdd('w3c', True)
_WD_CapabilitiesAdd('debuggerAddress', 'localhost:9222')
```

results:
```json
{
    "capabilities":{
        "firstMatch":[
            {
                "goog:chromeOptions":{
                    "w3c":true,
                    "debuggerAddress":"localhost:9222"
                }
            }
        ]
    }
}
```

### Additional context

https://www.autoitscript.com/forum/topic/207753-counting-the-number-of-tabs-on-a-browser-moved/?do=findComment&comment=1498641

### System under test
- Browser **Chrome/Opera**
