### PR TITLE
_WD_CapabilitiesAdd() Default parameters value

### DIFF
--- a/wd_capabilities.au3
+++ b/wd_capabilities.au3
@@ -155,9 +155,9 @@ EndFunc   ;==>_WD_CapabilitiesStartup
 ; Name ..........: _WD_CapabilitiesAdd
 ; Description ...: Add capablitities to JSON string
 ; Syntax ........: _WD_CapabilitiesAdd($key[, $value1 = ''[, $value2 = '']])
-; Parameters ....: $key            - Capability or Match type defined in $_WD_KEYS__*
-;                  $value1              - [optional] a variant value. Default is ''.
-;                  $value2              - [optional] a variant value. Default is ''.
+; Parameters ....: $key                 - Capability or Match type defined in $_WD_KEYS__*
+;                  $value1              - [optional] a variant value. Default is Default.
+;                  $value2              - [optional] a variant value. Default is Default.
 ; Return values .: None
 ; Return values .: Success - none.
 ;                  Failure - none and sets @error to one of the following values:
@@ -171,11 +171,11 @@ EndFunc   ;==>_WD_CapabilitiesStartup
 ; Link ..........:
 ; Example .......: https://www.autoitscript.com/wiki/WebDriver#Advanced_Capabilities_example
 ; ===============================================================================================================================
-Func _WD_CapabilitiesAdd($key, $value1 = '', $value2 = '')
+Func _WD_CapabilitiesAdd($key, $value1 = Default, $value2 = Default)
 	Local Const $sFuncName = "_WD_CapabilitiesAdd"
 
-	If $value1 = Default Then $value1 = 'default'
-	If $value2 = Default Then $value2 = 'default'
+	If $value1 = Default Then $value1 = ''
+	If $value2 = Default Then $value2 = ''
 	Local Const $s_Parameters_Info = '     $key = ' & $key & '     $value1 = ' & $value1 & '     $value2 = ' & $value2
 
 	If StringRegExp($key, $_WD_KEYS__MATCHTYPES, $STR_REGEXPMATCH) Then ; check if alwaysMatch|firstMatch

--- a/wd_capabilities.au3
+++ b/wd_capabilities.au3
@@ -156,8 +156,8 @@ EndFunc   ;==>_WD_CapabilitiesStartup
 ; Description ...: Add capablitities to JSON string
 ; Syntax ........: _WD_CapabilitiesAdd($key[, $value1 = ''[, $value2 = '']])
 ; Parameters ....: $key                 - Capability or Match type defined in $_WD_KEYS__*
-;                  $value1              - [optional] a variant value. Default is Default.
-;                  $value2              - [optional] a variant value. Default is Default.
+;                  $value1              - [optional] a variant value. Default is ''.
+;                  $value2              - [optional] a variant value. Default is ''.
 ; Return values .: None
 ; Return values .: Success - none.
 ;                  Failure - none and sets @error to one of the following values:


### PR DESCRIPTION
## Pull request

### Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.<br>
Please ensure you have read and noticed the checklist below.

### Checklist

Put an `x` in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We are here to help!<br>
This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [ ] Bugfix (change which fixes an issue)
- [x] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [x] Other (please describe) **SCRIPT BREAKING CHANGE**

Old way to use `"--profile-directory"` (Keyword `Default`):
```autoit
	_WD_CapabilitiesAdd("args", "--profile-directory", Default)
```


New proper way to use `"--profile-directory"`  (string `"Default"`):
```autoit
	_WD_CapabilitiesAdd("args", "--profile-directory", 'Default')
```


### What is the current behavior?

not common usage
`$value1 = '', $value2 = ''`

### What is the new behavior?

common usage
`$value1 = Default, $value2 = Default`

### Additional context

https://github.com/Danp2/au3WebDriver/issues/105#issuecomment-1092177616

### System under test

Not related
