### PR TITLE
__WD_ConsoleWrite() $_WD_DEBUG_Full + $sMsg

### DIFF
--- a/wd_core.au3
+++ b/wd_core.au3
@@ -1708,7 +1708,7 @@ EndFunc   ;==>__WD_StripPath
 
 Func __WD_ConsoleWrite($sMsg, $iDebugLevel = Default, $iError = @error, $iExtended = @extended)
 	If $iDebugLevel = Default Or $_WD_DEBUG >= $iDebugLevel Then
-		If $iDebugLevel = $_WD_DEBUG_Full Then $sMsg = ':$_WD_DEBUG_Full: (' & $iError & '/' & $iExtended & ') : ' & $sMsg
+		If $iDebugLevel = $_WD_DEBUG_Full Then $sMsg &= ' [' & $iError & '/' & $iExtended & ']
 		If IsFunc($_WD_CONSOLE) Then
 			Call($_WD_CONSOLE, $sMsg & $_WD_CONSOLE_Suffix)
 		ElseIf $_WD_CONSOLE = Null Then

--- a/wd_core.au3
+++ b/wd_core.au3
@@ -1709,6 +1709,7 @@ EndFunc   ;==>__WD_StripPath
 Func __WD_ConsoleWrite($sMsg, $iDebugLevel = Default, $iError = @error, $iExtended = @extended)
 	If $iDebugLevel = Default Or $_WD_DEBUG >= $iDebugLevel Then
 		If IsFunc($_WD_CONSOLE) Then
+			If IsNumber($iDebugLevel) And $iDebugLevel = $_WD_DEBUG_Full Then $sMsg = ':$_WD_DEBUG_Full: (' & $iError & '/' & $iExtended & ') : ' & $sMsg
 			Call($_WD_CONSOLE, $sMsg & $_WD_CONSOLE_Suffix)
 		ElseIf $_WD_CONSOLE = Null Then
 			; do nothing

--- a/wd_core.au3
+++ b/wd_core.au3
@@ -1708,8 +1708,8 @@ EndFunc   ;==>__WD_StripPath
 
 Func __WD_ConsoleWrite($sMsg, $iDebugLevel = Default, $iError = @error, $iExtended = @extended)
 	If $iDebugLevel = Default Or $_WD_DEBUG >= $iDebugLevel Then
+		If $iDebugLevel = $_WD_DEBUG_Full Then $sMsg = ':$_WD_DEBUG_Full: (' & $iError & '/' & $iExtended & ') : ' & $sMsg
 		If IsFunc($_WD_CONSOLE) Then
-			If IsNumber($iDebugLevel) And $iDebugLevel = $_WD_DEBUG_Full Then $sMsg = ':$_WD_DEBUG_Full: (' & $iError & '/' & $iExtended & ') : ' & $sMsg
 			Call($_WD_CONSOLE, $sMsg & $_WD_CONSOLE_Suffix)
 		ElseIf $_WD_CONSOLE = Null Then
 			; do nothing

--- a/wd_core.au3
+++ b/wd_core.au3
@@ -1708,7 +1708,7 @@ EndFunc   ;==>__WD_StripPath
 
 Func __WD_ConsoleWrite($sMsg, $iDebugLevel = Default, $iError = @error, $iExtended = @extended)
 	If $iDebugLevel = Default Or $_WD_DEBUG >= $iDebugLevel Then
-		If $iDebugLevel = $_WD_DEBUG_Full Then $sMsg &= ' [' & $iError & '/' & $iExtended & ']
+		If $iDebugLevel = $_WD_DEBUG_Full Then $sMsg &= ' [' & $iError & '/' & $iExtended & ']'
 		If IsFunc($_WD_CONSOLE) Then
 			Call($_WD_CONSOLE, $sMsg & $_WD_CONSOLE_Suffix)
 		ElseIf $_WD_CONSOLE = Null Then


### PR DESCRIPTION
## Pull request

### Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.<br>
Please ensure you have read and noticed the checklist below.

### Checklist

Put an `x` in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We are here to help!<br>
This is simply a reminder of what we are going to look for before merging your code.

- [ ] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [ ] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [ ] Bugfix (change which fixes an issue)
- [x] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

Lack of Err/Ext information in case of debuging I mean when `$_WD_DEBUG_Full` is set 


### What is the new behavior?

Additionall Err/Ext information in the message in case `$_WD_DEBUG_Full` is used with `__WD_ConsoleWrite()`.

Distinguishable Developer / Debugging messages.

### Additional context

https://github.com/Danp2/au3WebDriver/issues/280

### System under test

NotRelated