### PR TITLE
WD_WaitElement() Fix for $bCheckNoMatch usage

### DIFF
--- a/wd_demo.au3
+++ b/wd_demo.au3
@@ -339,6 +339,10 @@ Func DemoElements()
 	Local $sElement, $aElements, $sValue, $sButton, $sResponse, $bDecode, $hFileOpen
 
 	_WD_Navigate($sSession, "https://google.com")
+	_WD_LoadWait($sSession, Default, 1000 * 10)
+
+	; Check if body DIV element is visible, as it can be hide all sub elements in case when COOKIE aproval message is visible
+	_WD_WaitElement($sSession, $_WD_LOCATOR_ByXPath, '//body/div[1][@aria-hidden="true"]', 0, 1000 * 60, $_WD_OPTION_NoMatch)
 
 	; Locate a single element
 	$sElement = _WD_FindElement($sSession, $_WD_LOCATOR_ByXPath, $sElementSelector)

--- a/wd_demo.au3
+++ b/wd_demo.au3
@@ -339,14 +339,6 @@ Func DemoElements()
 	Local $sElement, $aElements, $sValue, $sButton, $sResponse, $bDecode, $hFileOpen
 
 	_WD_Navigate($sSession, "https://google.com")
-	_WD_LoadWait($sSession)
-
-	; Check if first DIV element is visible, as it can hide all sub elements in case when COOKIE aproval message is visible
-	_WD_WaitElement($sSession, $_WD_LOCATOR_ByXPath, '//body/div[1][@aria-hidden="true"]', 0, 1000 * 60, $_WD_OPTION_NoMatch)
-	If @error Then
-		ConsoleWrite("wd_demo.au3: (" & @ScriptLineNumber & ") : The page view is hidden - it is possible that the message about COOCKIE files was not accepted")
-		Return SetError(@error, @extended)
-	EndIf
 
 	; Locate a single element
 	$sElement = _WD_FindElement($sSession, $_WD_LOCATOR_ByXPath, $sElementSelector)

--- a/wd_demo.au3
+++ b/wd_demo.au3
@@ -339,9 +339,9 @@ Func DemoElements()
 	Local $sElement, $aElements, $sValue, $sButton, $sResponse, $bDecode, $hFileOpen
 
 	_WD_Navigate($sSession, "https://google.com")
-	_WD_LoadWait($sSession, Default, 1000 * 10)
+	_WD_LoadWait($sSession)
 
-	; Check if body DIV element is visible, as it can be hide all sub elements in case when COOKIE aproval message is visible
+	; Check if first DIV element is visible, as he can hide all sub elements in case when COOKIE aproval message is visible
 	_WD_WaitElement($sSession, $_WD_LOCATOR_ByXPath, '//body/div[1][@aria-hidden="true"]', 0, 1000 * 60, $_WD_OPTION_NoMatch)
 
 	; Locate a single element

--- a/wd_demo.au3
+++ b/wd_demo.au3
@@ -343,6 +343,10 @@ Func DemoElements()
 
 	; Check if first DIV element is visible, as it can hide all sub elements in case when COOKIE aproval message is visible
 	_WD_WaitElement($sSession, $_WD_LOCATOR_ByXPath, '//body/div[1][@aria-hidden="true"]', 0, 1000 * 60, $_WD_OPTION_NoMatch)
+	If @error Then
+		ConsoleWrite("wd_demo.au3: (" & @ScriptLineNumber & ") : The page view is hidden - it is possible that the message about COOCKIE files was not accepted")
+		Return SetError(@error, @extended)
+	EndIf
 
 	; Locate a single element
 	$sElement = _WD_FindElement($sSession, $_WD_LOCATOR_ByXPath, $sElementSelector)

--- a/wd_demo.au3
+++ b/wd_demo.au3
@@ -341,7 +341,7 @@ Func DemoElements()
 	_WD_Navigate($sSession, "https://google.com")
 	_WD_LoadWait($sSession)
 
-	; Check if first DIV element is visible, as he can hide all sub elements in case when COOKIE aproval message is visible
+	; Check if first DIV element is visible, as it can hide all sub elements in case when COOKIE aproval message is visible
 	_WD_WaitElement($sSession, $_WD_LOCATOR_ByXPath, '//body/div[1][@aria-hidden="true"]', 0, 1000 * 60, $_WD_OPTION_NoMatch)
 
 	; Locate a single element

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -344,7 +344,7 @@ Func _WD_WaitElement($sSession, $sStrategy, $sSelector, $iDelay = Default, $iTim
 				$iErr = $_WD_ERROR_Success
 				ExitLoop
 
-			ElseIf $iErr = $_WD_ERROR_Success Then
+			ElseIf $iErr = $_WD_ERROR_Success And Not $bCheckNoMatch Then
 				If $bVisible Then
 					$bIsVisible = _WD_ElementAction($sSession, $sElement, 'displayed')
 


### PR DESCRIPTION
## Pull request

### Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.<br>
Please ensure you have read and noticed the checklist below.

### Checklist

Put an `x` in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We are here to help!<br>
This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [x] Bugfix (change which fixes an issue)
- [ ] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

Was not able to set `$sElementSelector` value in case when Cookie Aproval message was visible

### What is the new behavior?

waiting on user aprove Cookie request

### Additional context

https://github.com/Danp2/au3WebDriver/issues/254#issuecomment-1096874196

### System under test

not related
