### PR TITLE
$_WD_HTTPRESPONSE cleared as $_WD_HTTPRESULT

### DIFF
--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -318,6 +318,7 @@ Func _WD_WaitElement($sSession, $sStrategy, $sSelector, $iDelay = Default, $iTim
 	Local Const $sFuncName = "_WD_WaitElement"
 	Local $iErr, $sElement, $bIsVisible = True, $bIsEnabled = True
 	$_WD_HTTPRESULT = 0
+	$_WD_HTTPRESPONSE = ''
 
 	If $iDelay = Default Then $iDelay = 0
 	If $iTimeout = Default Then $iTimeout = $_WD_DefaultTimeout
@@ -665,6 +666,7 @@ Func _WD_HighlightElements($sSession, $vElements, $iMethod = Default)
 			]
 	Local $sScript, $sResult, $iErr, $sElements
 	$_WD_HTTPRESULT = 0
+	$_WD_HTTPRESPONSE = ''
 
 	If $iMethod = Default Then $iMethod = 1
 	If $iMethod < 0 Or $iMethod > 3 Then $iMethod = 1
@@ -711,6 +713,7 @@ Func _WD_LoadWait($sSession, $iDelay = Default, $iTimeout = Default, $sElement =
 	Local Const $sFuncName = "_WD_LoadWait"
 	Local $iErr, $sReadyState
 	$_WD_HTTPRESULT = 0
+	$_WD_HTTPRESPONSE = ''
 
 	If $iDelay = Default Then $iDelay = 0
 	If $iTimeout = Default Then $iTimeout = $_WD_DefaultTimeout
@@ -1702,6 +1705,7 @@ Func _WD_SetTimeouts($sSession, $iPageLoad = Default, $iScript = Default, $iImpl
 	Local Const $sFuncName = "_WD_SetTimeouts"
 	Local $sTimeouts = '', $sResult = 0, $bIsNull, $iErr
 	$_WD_HTTPRESULT = 0
+	$_WD_HTTPRESPONSE = ''
 
 	; Build string to pass to _WD_Timeouts
 	If $iPageLoad <> Default Then
@@ -1889,6 +1893,7 @@ Func _WD_ElementActionEx($sSession, $sElement, $sCommand, $iXOffset = Default, $
 	Local Const $sFuncName = "_WD_ElementActionEx"
 	Local $sAction, $sJavascript, $iErr, $sResult, $iActionType = 1
 	$_WD_HTTPRESULT = 0
+	$_WD_HTTPRESPONSE = ''
 
 	If $iXOffset = Default Then $iXOffset = 0
 	If $iYOffset = Default Then $iYOffset = 0
@@ -2046,6 +2051,7 @@ Func _WD_GetTable($sSession, $sBaseElement)
 	Local Const $sFuncName = "_WD_GetTable"
 	Local $aElements, $sElement, $iLines, $iRow, $iColumns, $iColumn, $sHTML
 	$_WD_HTTPRESULT = 0
+	$_WD_HTTPRESPONSE = ''
 
 	; Determine if optional UDF is available
 	Call("_HtmlTableGetWriteToArray", "")


### PR DESCRIPTION
## Pull request

### Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.<br>
Please ensure you have read and noticed the checklist below.

### Checklist

Put an `x` in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We are here to help!<br>
This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [ ] Bugfix (change which fixes an issue)
- [x] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

`$_WD_HTTPRESPONSE` is not always cleared

### What is the new behavior?

`$_WD_HTTPRESPONSE = ''` must be reset as well as `$_WD_HTTPRESULT = 0`

### Additional context

https://github.com/Danp2/au3WebDriver/pull/295#issuecomment-1101715311

### System under test

Not Related