### PR TITLE
Create wd_downloadManager.au3

### DIFF
--- a/wd_downloadManager.au3
+++ b/wd_downloadManager.au3
@@ -1,0 +1,63 @@
+; #FUNCTION# ====================================================================================================================
+; Name ..........: _WD_getDownloadProgress
+; Description ...: Give the progression of the Download in firefox.
+; Syntax ........: _WD_getDownloadProgress($sSession)
+; Parameters ....: $sSession - Session ID from _WD_CreateSession
+; Return values .: Success - $actualValue value in percentage
+;                  Failure - Boolean False
+; Author ........: AByGCreation
+; Modified ......:
+; Remarks .......:
+; Related .......: elementWaiter
+; Link ..........:
+; Example .......: No
+; ===============================================================================================================================
+Func _WD_getDownloadProgress($sSession)
+
+	Local Const $sFuncName = "_WD_getDownloadProgress"
+
+	If not(_WD_Action($sSession, 'url') == "about:downloads" ) Then
+		_WD_NewTab($sSession)
+		_WD_Navigate($sSession, "about:downloads" )
+	EndIf
+
+	If elementWaiter($sSession,  '//*[@class="downloadProgress"]',  100) Then
+			$sElement =  _WD_FindElement($sSession, $_WD_LOCATOR_ByXPath, '//*[@class="downloadProgress"]')
+			$actualValue =  _WD_ElementAction($sSession, $sElement, "value")
+
+			return $actualValue
+	Else
+			return false
+	EndIf
+EndFunc
+
+; #FUNCTION# ====================================================================================================================
+; Name ..........: elementWaiter
+; Description ...: Give the progression of the Download in firefox.
+; Syntax ........: elementWaiter($sSession, $xPath, $maxTry)
+; Parameters ....: $sSession - Session ID from _WD_CreateSession
+;~ 					$xPath 	- xPath syntax
+;~ 					$maxTry - Number of retrying, equivalent to timeout
+; Return values .: Success - Boolean true
+;                  Failure - Boolean False
+; Author ........: AByGCreation
+; Modified ......:
+; Remarks .......:
+; Related .......: _WD_WaitElement
+; Link ..........:
+; Example .......: No
+; ===============================================================================================================================
+Func elementWaiter($sSession, $xPath, $maxTry = 20)
+	Local Const $sFuncName = "elementWaiter"
+	local $i = 0
+
+	While _WD_WaitElement($sSession, $_WD_LOCATOR_ByXPath, $xPath, 500) = ""
+		if($i < $maxTry) Then
+			$i = $i + 1
+		Else
+			return false
+		EndIf
+	wend
+	return true
+
+EndFunc   ;==>elementWaiter


### PR DESCRIPTION
## Pull request

### Proposed changes

The purpose is to creat a download Manager to get the progress value of a download in any browsers.
For the moment I try with FF

### Checklist

Put an `x` in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We are here to help!<br>
This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [x] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [ ] Bugfix (change which fixes an issue)
- [x] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

When you request a file on a distant server, you can download it, but you can't get the progression. 

### What is the new behavior?

By the way in scraping the download tab of FF, you can ! 
It's the best way I found to get this value.

### Additional context



### System under test



- OS: [Windows 10]
- OS Arch.: [X64]
- Browser [geckodriver]
- Browser version [0.7.0]
