### PR TITLE
Added $_WD_ErrorSelectorInvalid

### DIFF
--- a/wd_core.au3
+++ b/wd_core.au3
@@ -104,7 +104,7 @@ Global Enum _
 		$_WD_ERROR_NoMatch, _ ; No match for _WDAction-find/search _WDGetElement...
 		$_WD_ERROR_RetValue, _ ; Error echo from Repl e.g. _WDAction("fullscreen","true") <> "true"
 		$_WD_ERROR_Exception, _ ; Exception from web driver
-		$_WD_ERROR_InvalidExpression, _ ; Invalid expression in XPath query or RegEx
+		$_WD_ERROR_InvalidExpression, _ ; Invalid expression in XPath query, CSSSelector query or RegEx
 		$_WD_ERROR_NoAlert, _ ; No alert present when calling _WD_Alert
 		$_WD_ERROR_NotFound, _ ;
 		$_WD_ERROR_ElementIssue, _ ;
@@ -161,6 +161,7 @@ Global Const $_WD_ErrorNoSuchAlert = "no such alert"
 Global Const $_WD_ErrorElementNotFound = "no such element"
 Global Const $_WD_ErrorElementStale = "stale element reference"
 Global Const $_WD_ErrorElementInvalid = "invalid argument"
+Global Const $_WD_ErrorSelectorInvalid = "invalid selector"
 Global Const $_WD_ErrorElementIntercept = "element click intercepted"
 Global Const $_WD_ErrorElementNotInteract = "element not interactable"
 
@@ -1252,7 +1253,7 @@ Func _WD_Startup()
 		EndIf
 
 		If _WinAPI_GetBinaryType($_WD_DRIVER) Then _
-			$sDriverBitness = ((@extended = $SCS_64BIT_BINARY) ? (" (64 Bit)") : (" (32 Bit)"))
+				$sDriverBitness = ((@extended = $SCS_64BIT_BINARY) ? (" (64 Bit)") : (" (32 Bit)"))
 
 		__WD_ConsoleWrite($sFuncName & ": OS:" & @TAB & @OSVersion & " " & @OSType & " " & @OSBuild & " " & @OSServicePack)
 		__WD_ConsoleWrite($sFuncName & ": AutoIt:" & @TAB & @AutoItVersion)
@@ -1654,7 +1655,7 @@ EndFunc   ;==>__WD_TranslateQuotes
 ;                  $vResult - Result from webdriver
 ; Return values .: None
 ; Author ........: Danp2
-; Modified ......:
+; Modified ......: mLipok
 ; Remarks .......:
 ; Related .......:
 ; Link ..........:
@@ -1694,10 +1695,13 @@ Func __WD_DetectError(ByRef $iErr, $vResult)
 
 			Case $_WD_ErrorTimeout
 				$iErr = $_WD_ERROR_Timeout
+
 			Case $_WD_ErrorElementNotFound, $_WD_ErrorElementStale
 				$iErr = $_WD_ERROR_NoMatch
+
 			Case $_WD_ErrorElementInvalid
 				$iErr = $_WD_ERROR_InvalidArgue
+
 			Case $_WD_ErrorElementIntercept, $_WD_ErrorElementNotInteract
 				$iErr = $_WD_ERROR_ElementIssue
 
@@ -1710,6 +1714,9 @@ Func __WD_DetectError(ByRef $iErr, $vResult)
 				Else
 					$iErr = $_WD_ERROR_Javascript
 				EndIf
+
+			Case $_WD_ErrorSelectorInvalid
+				$iErr = $_WD_ERROR_InvalidExpression
 
 			Case Else
 				$iErr = $_WD_ERROR_Exception


### PR DESCRIPTION
## Pull request

### Proposed changes

https://github.com/Danp2/au3WebDriver/issues/314

### Checklist

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [ ] Bugfix (change which fixes an issue)
- [x] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

https://github.com/Danp2/au3WebDriver/issues/314

### What is the new behavior?

with:
```autoit
Func UserTesting() ; here you can replace the code to test your stuff before you ask on the forum
	_WD_Navigate($sSession, 'https://www.google.com')
	_WD_LoadWait($sSession)
	_WD_FindElement($sSession, $_WD_LOCATOR_ByXPath, '%')
	_WD_FindElement($sSession, $_WD_LOCATOR_ByCSSSelector, '%')
;~ 	Exit
EndFunc   ;==>UserTesting
```

I get:
```
__WD_Post: URL=HTTP://127.0.0.1:4444/session/7526c6bd-aa25-4079-94c9-f77632fee4e6/element; $sData={"using":"xpath","value":"%"}
__WD_Post ==> Invalid Expression (11) HTTP status = 400 : ResponseText={"value":{"error":"invalid selector","message":"Given xpath expression \"%\" is invalid: SyntaxError...
_WD_FindElement ==> Invalid Expression (11) HTTP status = 400 : {"value":{"error":"invalid selector","message":"Given xpath expression \"%\" is invalid: SyntaxError: Document.evaluate: The expression is not a legal expression","stacktrace":"WebDriverError@chrome://remote/content/shared/webdriver/Errors.jsm:183:5\nInvalidSelectorError@chrome://remote/content/shared/webdriver/Errors.jsm:343:5\nfind_@chrome://remote/content/marionette/element.js:328:11\nelement.find/</findElements<@chrome://remote/content/marionette/element.js:282:24\nevalFn@chrome://remote/content/marionette/sync.js:134:7\nPollPromise/<@chrome://remote/content/marionette/sync.js:154:5\nPollPromise@chrome://remote/content/marionette/sync.js:125:10\nelement.find/<@chrome://remote/content/marionette/element.js:280:24\nelement.find@chrome://remote/content/marionette/element.js:279:10\nfindElement@chrome://remote/content/marionette/actors/MarionetteCommandsChild.jsm:243:20\nreceiveMessage@chrome://remote/content/marionette/actors/MarionetteCommandsChild.jsm:99:31\n"}}
__WD_Post: URL=HTTP://127.0.0.1:4444/session/7526c6bd-aa25-4079-94c9-f77632fee4e6/element; $sData={"using":"css selector","value":"%"}
__WD_Post ==> Invalid Expression (11) HTTP status = 400 : ResponseText={"value":{"error":"invalid selector","message":"Given css selector expression \"%\" is invalid: Inva...
_WD_FindElement ==> Invalid Expression (11) HTTP status = 400 : {"value":{"error":"invalid selector","message":"Given css selector expression \"%\" is invalid: InvalidSelectorError: Document.querySelector: '%' is not a valid selector: \"%\"","stacktrace":"WebDriverError@chrome://remote/content/shared/webdriver/Errors.jsm:183:5\nInvalidSelectorError@chrome://remote/content/shared/webdriver/Errors.jsm:343:5\nfind_@chrome://remote/content/marionette/element.js:328:11\nelement.find/</findElements<@chrome://remote/content/marionette/element.js:282:24\nevalFn@chrome://remote/content/marionette/sync.js:134:7\nPollPromise/<@chrome://remote/content/marionette/sync.js:154:5\nPollPromise@chrome://remote/content/marionette/sync.js:125:10\nelement.find/<@chrome://remote/content/marionette/element.js:280:24\nelement.find@chrome://remote/content/marionette/element.js:279:10\nfindElement@chrome://remote/content/marionette/actors/MarionetteCommandsChild.jsm:243:20\nreceiveMessage@chrome://remote/content/marionette/actors/MarionetteCommandsChild.jsm:99:31\n"}}

```

### Additional context

https://github.com/Danp2/au3WebDriver/issues/314

### System under test

Not related