### PR TITLE
Added $_WD_ERROR_JSON - Failed to decode request as JSON

### DIFF
--- a/wd_core.au3
+++ b/wd_core.au3
@@ -152,7 +152,7 @@ Global Const $aWD_ERROR_DESC[$_WD_ERROR_COUNTER] = [ _
 		"Browser or feature not supported", _
 		"Capability or value already defined", _
 		"Javascript Exception", _
-		"Failed to decode request as JSON" _
+		"JSON Exception" _
 		]
 
 Global Const $_WD_ErrorInvalidSession = "invalid session id"

--- a/wd_core.au3
+++ b/wd_core.au3
@@ -1701,12 +1701,7 @@ Func __WD_DetectError(ByRef $iErr, $vResult)
 				$iErr = $_WD_ERROR_NoMatch
 
 			Case $_WD_ErrorElementInvalid
-				If StringInStr($vResult.item('message'), 'Failed to decode request as JSON') Then
-					$iErr = $_WD_ERROR_JSON
-				Else
-					$iErr = $_WD_ERROR_InvalidArgue
-				EndIf
-
+				$iErr = $_WD_ERROR_InvalidArgue
 
 			Case $_WD_ErrorElementIntercept, $_WD_ErrorElementNotInteract
 				$iErr = $_WD_ERROR_ElementIssue
@@ -1725,8 +1720,12 @@ Func __WD_DetectError(ByRef $iErr, $vResult)
 				$iErr = $_WD_ERROR_InvalidExpression
 
 			Case Else
-				__WD_ConsoleWrite($sFuncName & ": Not identified type of message: " & $vResult.item('message'), $_WD_DEBUG_Full)
-				$iErr = $_WD_ERROR_Exception
+				If StringInStr($vResult.item('message'), 'Failed to decode request as JSON') Then
+					$iErr = $_WD_ERROR_JSON
+				Else
+					__WD_ConsoleWrite($sFuncName & ": Not identified type of message: " & $vResult.item('message'), $_WD_DEBUG_Full)
+					$iErr = $_WD_ERROR_Exception
+				EndIf
 
 		EndSwitch
 	EndIf

--- a/wd_core.au3
+++ b/wd_core.au3
@@ -220,7 +220,7 @@ Global $_WD_SupportedBrowsers[][$_WD_BROWSER__COUNTER] = _
 ; ===============================================================================================================================
 Func _WD_CreateSession($sCapabilities = Default)
 	Local Const $sFuncName = "_WD_CreateSession"
-	Local $sSession = ""
+	Local $sSession = "", $sMessage = ''
 
 	If $sCapabilities = Default Then $sCapabilities = $_WD_EmptyDict
 
@@ -234,15 +234,15 @@ Func _WD_CreateSession($sCapabilities = Default)
 		$sSession = Json_Get($oJSON, "[value][sessionId]")
 
 		If @error Then
-			Local $sMessage = Json_Get($oJSON, "[value][message]")
-			$iErr = $_WD_ERROR_JSON
+			$sMessage = Json_Get($oJSON, "[value][message]")
+			$iErr = $_WD_ERROR_Exception
 		EndIf
 	EndIf
 
 	; Save response details for future use
 	$_WD_SESSION_DETAILS = $sResponse
 
-	Return SetError(__WD_Error($sFuncName, $iErr), 0, $sSession)
+	Return SetError(__WD_Error($sFuncName, $iErr, $sMessage), 0, $sSession)
 EndFunc   ;==>_WD_CreateSession
 
 ; #FUNCTION# ====================================================================================================================


### PR DESCRIPTION
## Pull request

### Proposed changes

capturing $_WD_ERROR_JSON - Failed to decode request as JSON

### Checklist

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [ ] Bugfix (change which fixes an issue)
- [x] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

after such error:
`__WD_Post ==> Invalid argument (5) HTTP status = 400 : ResponseText={"value":{"error":"invalid argument","message":"Failed to decode request as JSON: ","stacktrace":"Syntax error at :1:0"}}...`

UDF set error to `$_WD_ERROR_Exception`


### What is the new behavior?

**Feature 1:**

after such error:
`__WD_Post ==> Failed to decode request as JSON (22) HTTP status = 400 : ResponseText={"value":{"error":"invalid argument","message":"Failed to decode request as JSON: ","stacktrace":"Syntax error at :1:0"}}...`

UDF set error to `$_WD_ERROR_JSON` and description to: `Failed to decode request as JSON`

Example from here: https://github.com/Danp2/au3WebDriver/pull/320#issuecomment-1143296412
```
__WD_Post ==> Failed to decode request as JSON (22) HTTP status = 400 : ResponseText={"value":{"error":"invalid argument","message":"Failed to decode request as JSON: ","stacktrace":"Syntax error at :1:0"}}...
_WD_CreateSession: {"value":{"error":"invalid argument","message":"Failed to decode request as JSON: ","stacktrace":"Syntax error at :1:0"}}
_WD_CreateSession ==> Failed to decode request as JSON (22) HTTP status = 400
```

**Feature 2:**

also this part of `__WD_DetectError` :

```autoit
Case Else
      __WD_ConsoleWrite($sFuncName & ": Not identified type of message: " & $vResult.item('message'), $_WD_DEBUG_Full)
      $iErr = $_WD_ERROR_Exception
```

helps us to catch not detected error types.

It will help in the future to create new ERROR enums which helps to minimize the need to use `$_WD_DEBUG_Full`


### Additional context

https://github.com/Danp2/au3WebDriver/pull/320#issuecomment-1143275328

https://github.com/Danp2/au3WebDriver/pull/290

### System under test

not related
