### PR TITLE
_WD_CapabilitiesGet added $_WD_EmptyDict usage

### DIFF
--- a/wd_capabilities.au3
+++ b/wd_capabilities.au3
@@ -297,6 +297,8 @@ Func _WD_CapabilitiesGet()
 
 	Local $Data3 = Json_Decode($Json2)
 	Local $Json3 = Json_Encode($Data3, $Json_PRETTY_PRINT, "    ", ",\n", ",\n", ":")
+	
+	If $Json3 = '' Or $Json3 = '""' Or Not IsString($Json3) Then $Json3 = $_WD_EmptyDict
 
 	Return $Json3
 EndFunc   ;==>_WD_CapabilitiesGet


### PR DESCRIPTION
## Pull request

### Proposed changes

I had issue with Attaching to existing FF instance. The problem was that _WD_CapabilitiesGet() returns in some cases not proper JSON string



### Checklist

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

- [x] Bugfix (change which fixes an issue)
- [ ] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?


This following script works fine as far as you use `_WD_CapabilitiesStartup()` 
```autoit
_WD_CapabilitiesStartup()
Local $s_Capabilities = _WD_CapabilitiesGet()
```

you will skip the _WD_CapabilitiesStartup() function call then it returns `""`

### What is the new behavior?

this following line
```autoit
If $Json3 = '' Or $Json3 = '""' Or Not IsString($Json3) Then $Json3 = $_WD_EmptyDict
```

prevents such an error, and a potentially similar one.


### Additional context

none

### System under test

not related