### PR TITLE
$_WD_ERROR_UserAbort support in _WD_LoadWait

### DIFF
--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -715,7 +715,10 @@ Func _WD_LoadWait($sSession, $iDelay = Default, $iTimeout = Default, $sElement =
 		EndIf
 
 		__WD_Sleep(10)
-		$iErr = @error
+		If @error Then 
+			$iErr = @error
+			ExitLoop
+		EndIf
 	WEnd
 
 	If $iErr Then


### PR DESCRIPTION
## Pull request

### Proposed changes

each `__WD_Sleep` should support `$_WD_ERROR_UserAbort`
`_WD_LoadWait` was not checking for such errror

### Checklist

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [x] Bugfix (change which fixes an issue)
- [ ] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?
`_WD_LoadWait` is not checking for  `$_WD_ERROR_UserAbort` returned from `__WD_Sleep` 

### What is the new behavior?
`_WD_LoadWait` checks for  `$_WD_ERROR_UserAbort` returned from `__WD_Sleep` 

### Additional context

none

### System under test

not related