### PR TITLE
_WD_SetElementValue $_WD_OPTION_Advanced usage

### DIFF
--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -1910,7 +1910,17 @@ Func _WD_SetElementValue($sSession, $sElement, $sValue, $iStyle = Default)
 			$iErr = @error
 
 		Case $_WD_OPTION_Advanced
-			$sScript = "Object.getOwnPropertyDescriptor(arguments[0].__proto__, 'value').set.call(arguments[0], arguments[1]);arguments[0].dispatchEvent(new Event('input', { bubbles: true }));"
+			$sScript = _
+					"arguments[0].value = arguments[1];" & _
+					"var event;" & _
+					"if (typeof(Event) === 'function') {" & _
+					" event = new Event('change');" & _
+					"} else {" & _
+					" event = document.createEvent('Event');" & _
+					" event.initEvent('change', true, true);" & _
+					"};" & _
+					"arguments[0].dispatchEvent(event);" & _
+					""
 			$sResult = _WD_ExecuteScript($sSession, $sScript, __WD_JsonElement($sElement) & ',"' & $sValue & '"')
 			$iErr = @error
 

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -1891,7 +1891,7 @@ EndFunc   ;==>_WD_GetElementByName
 ;                  - $_WD_ERROR_InvalidDataType
 ;                  - $_WD_ERROR_InvalidExpression
 ; Author ........: Danp2
-; Modified ......:
+; Modified ......: mLipok, TheDcoder
 ; Remarks .......:
 ; Related .......: _WD_ElementAction, _WD_LastHTTPResult
 ; Link ..........:
@@ -1911,15 +1911,9 @@ Func _WD_SetElementValue($sSession, $sElement, $sValue, $iStyle = Default)
 
 		Case $_WD_OPTION_Advanced
 			$sScript = _
-					"arguments[0].value = arguments[1];" & _
-					"var event;" & _
-					"if (typeof(Event) === 'function') {" & _
-					" event = new Event('change');" & _
-					"} else {" & _
-					" event = document.createEvent('Event');" & _
-					" event.initEvent('change', true, true);" & _
-					"};" & _
-					"arguments[0].dispatchEvent(event);" & _
+					"Object.getOwnPropertyDescriptor(arguments[0].__proto__, 'value').set.call(arguments[0], arguments[1]);" & _
+					"arguments[0].dispatchEvent(new Event('input', {bubbles: true}));" & _
+					"arguments[0].dispatchEvent(new Event('change', {bubbles: true}));" & _
 					""
 			$sResult = _WD_ExecuteScript($sSession, $sScript, __WD_JsonElement($sElement) & ',"' & $sValue & '"')
 			$iErr = @error


### PR DESCRIPTION
## Pull request

### Proposed changes

Better `$_WD_OPTION_Advanced` implementation in `_WD_SetElementValue`

### Checklist

Put an `x` in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We are here to help!<br>
This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [x] Bugfix (change which fixes an issue)
- [ ] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

`_WD_SetElementValue` with `$_WD_OPTION_Advanced` still not always properly sets value.

### What is the new behavior?

`$_WD_OPTION_Advanced` fires `change` event for this reason all background processing are processed. 

### Additional context

None

### System under test

not related.
But mostly issue with setting value occurs on Firefox in case when Firefox was visible but was obscured by another window.