### PR TITLE
Add ability to control browser storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Go to [legend](#legend---types-of-changes) for further information about the typ
 
 - _WD_GetElementByRegEx (@TheDcoder)
 - _WD_ElementStyle 	(@mLipok)
+- _WD_Storage
 
 ### Changed
 


### PR DESCRIPTION
## Pull request

### Proposed changes

Add _WD_Storage function to allow manipulation of localStorage and sessionStorage

### Checklist

Put an `x` in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We are here to help!<br>
This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [ ] Bugfix (change which fixes an issue)
- [x] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

No simple way to access browser storage

### What is the new behavior?

UDF to control access to browser storage

### Additional context

Tested with variations of this code --

```autoit
Func UserTesting() ; here you can replace the code to test your stuff before you ask on the forum
	_WD_Navigate($sSession, 'https://www.google.com')
	_WD_LoadWait($sSession)

	$sResult = _WD_Storage($sSession, 'testing', '123')
	;### Debug CONSOLE ↓↓↓
	ConsoleWrite('@@ Debug(' & @ScriptLineNumber & ') : $sResult = ' & IsKeyword($sResult) & @CRLF & '>Error code: ' & @error & @CRLF)
	$sResult = _WD_Storage($sSession, 0)
	;### Debug CONSOLE ↓↓↓
	ConsoleWrite('@@ Debug(' & @ScriptLineNumber & ') : $sResult = ' & $sResult & @CRLF & '>Error code: ' & @error & @CRLF)
	$sResult = _WD_Storage($sSession, 'testing')
	;### Debug CONSOLE ↓↓↓
	ConsoleWrite('@@ Debug(' & @ScriptLineNumber & ') : $sResult = ' & $sResult & @CRLF & '>Error code: ' & @error & @CRLF)
	;~ $sResult = _WD_Storage($sSession, 'testing', Null)
	;~ $sResult = _WD_Storage($sSession, 'testing')
	;~ $sResult = _WD_Storage($sSession, Null)

EndFunc   ;==>UserTesting
```

### System under test

Please complete the following information.

- OS: [e.g. Windows 10]
- OS Arch.: [e.g. X64]
- Browser [e.g. firefox]
- Browser version [e.g. 96.0.3]
