### PR TITLE
_WD_ElementSelectAction: Selecting options +Events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Go to [legend](#legend---types-of-changes) for further information about the typ
 
 _WD_CDPExecuteCommand: Missing $ prefix in variable name
 _WD_CapabilitiesAdd: Support keys containing colons 
+_WD_ElementSelectAction: Altering selection now triggers Change event
 
 ## [0.10.0]
 

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -1008,7 +1008,10 @@ Func _WD_ElementSelectAction($sSession, $sSelectElement, $sCommand, $aParameters
 		If $sNodeName = 'select' Then ; check if designated element is <select> element
 			Switch $sCommand
 				Case 'deselectAll'
-					$sScript = "arguments[0].selectedIndex = -1; return true;"
+					$sScript = _
+							"arguments[0].selectedIndex = -1;" & _
+							"arguments[0].dispatchEvent(new Event('change', {bubbles: true}));" & _
+							"return true;"
 					$vResult = _WD_ExecuteScript($sSession, $sScript, __WD_JsonElement($sSelectElement), Default, $_WD_JSON_Value)
 					$iErr = @error
 
@@ -1026,7 +1029,9 @@ Func _WD_ElementSelectAction($sSession, $sSelectElement, $sCommand, $aParameters
 								"  {" & _
 								"    o.selected = true;" & _
 								"  }" & _
-								"}; return true;"
+								"};" & _
+								"arguments[0].dispatchEvent(new Event('change', {bubbles: true}));" & _
+								"return true;"
 						$vResult = _WD_ExecuteScript($sSession, $sScript, __WD_JsonElement($sSelectElement), Default, $_WD_JSON_Value)
 						$iErr = @error
 					EndIf
@@ -1051,6 +1056,7 @@ Func _WD_ElementSelectAction($sSession, $sSelectElement, $sCommand, $aParameters
 							"var options = arguments[0].options;" & _
 							"for ( i=0; i<options.length; i++)" & _
 							"  {if (options[i].disabled==false && (!(options.item(i).parentNode.nodeName =='OPTGROUP' && options.item(i).parentNode.disabled))) {options[i].selected = true}};" & _
+							"arguments[0].dispatchEvent(new Event('change', {bubbles: true}));" & _
 							"return true;"
 					$vResult = _WD_ExecuteScript($sSession, $sScript, __WD_JsonElement($sSelectElement), Default, $_WD_JSON_Value)
 					$iErr = @error


### PR DESCRIPTION
## Pull request

### Proposed changes

In some cases selecting options should fire Change and Bubbles events.
![image](https://user-images.githubusercontent.com/11089482/180866029-6c5e7d6d-ccac-49da-a3d6-4da57cad8e86.png)


### Checklist
- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [ ] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [x] Bugfix (change which fixes an issue)
- [ ] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?
_WD_ElementSelectAction not always properly select Options because DOM structure was not interacting with the change.

### What is the new behavior?
_WD_ElementSelectAction fires event to for DOM structure to notice the change.

### Additional context

https://github.com/Danp2/au3WebDriver/issues/344

### System under test

not related