### PR TITLE
Capability: deviceMetrics + Nested dictionary

### DIFF
--- a/wd_capabilities.au3
+++ b/wd_capabilities.au3
@@ -16,7 +16,7 @@
 ; Author ........: mLipok
 ; Modified ......: Danp2
 ; URL ...........: https://www.autoitscript.com/wiki/WebDriver_Capabilities
-; Date ..........: 2022/04/15
+; Date ..........: 2022/07/27
 ; ================================================================================
 
 #Region - wd_capabilities.au3 - Copyright
@@ -238,6 +238,7 @@ Func _WD_CapabilitiesAdd($key, $value1 = Default, $value2 = Default)
 	ElseIf StringRegExp($key, $_WD_KEYS__SPECIFICVENDOR_ARRAY, $STR_REGEXPMATCH) And $_WD_NOTATION__SPECIFICVENDOR <> '' Then ; add "JSON_ARRAY" capability in SPECIFIC/VENDOR part of Capabilities JSON Structure
 		$v_WatchPoint = @ScriptLineNumber
 		$s_Notation = $_WD_NOTATION__MATCHTYPE & $_WD_NOTATION__SPECIFICVENDOR
+		$key = StringReplace($key, '>', '"]' & '["')
 		$s_Notation &= '["' & $key & '"]'
 		Local $iCurrent2 = UBound(Json_Get($_WD_CAPS__OBJECT, $s_Notation))
 		SetError(0) ; for any case because UBound() can set @error

--- a/wd_capabilities.au3
+++ b/wd_capabilities.au3
@@ -120,7 +120,7 @@ Global $_WD_KEYS__SPECIFICVENDOR_ARRAY = _
 ; $_WD_KEYS__SPECIFICVENDOR_OBJECT should be RegExpPattern of "JSON_OBJECT" - "a dictionary element" that
 ; should be placed in SPECIFICVENDOR part of Capabilities JSON structure
 Global $_WD_KEYS__SPECIFICVENDOR_OBJECT = _
-		'\A(env|log|prefs|perfLoggingPrefs|mobileEmulation|localState)\Z'
+		'\A(env|log|prefs|perfLoggingPrefs|mobileEmulation|mobileEmulation>deviceMetrics|localState)\Z'
 
 #EndRegion - wd_capabilities.au3 UDF - Global's declarations
 
@@ -250,6 +250,7 @@ Func _WD_CapabilitiesAdd($key, $value1 = Default, $value2 = Default)
 	ElseIf StringRegExp($key, $_WD_KEYS__SPECIFICVENDOR_OBJECT, $STR_REGEXPMATCH) And $_WD_NOTATION__SPECIFICVENDOR <> '' Then ; add "JSON_OBJECT" capability in SPECIFIC/VENDOR part of Capabilities JSON Structure
 		$v_WatchPoint = @ScriptLineNumber
 		$s_Notation = $_WD_NOTATION__MATCHTYPE & $_WD_NOTATION__SPECIFICVENDOR
+		$key = StringReplace($key, '>', '"]' & '["')
 		$s_Notation &= '["' & $key & '"]' & '[' & $value1 & ']'
 		$value1 = $value2 ; switch
 
@@ -297,7 +298,7 @@ Func _WD_CapabilitiesGet()
 
 	Local $Data3 = Json_Decode($Json2)
 	Local $Json3 = Json_Encode($Data3, $Json_PRETTY_PRINT, "    ", ",\n", ",\n", ":")
-	
+
 	If $Json3 = '' Or $Json3 = '""' Or Not IsString($Json3) Then $Json3 = $_WD_EmptyDict
 
 	Return $Json3


### PR DESCRIPTION
## Pull request

### Proposed changes

Documentation from here:
https://sites.google.com/a/chromium.org/chromedriver/capabilities
says:
<html>
<body>
<!--StartFragment-->

mobileEmulation | dictionary |   | A dictionary with either a value for “deviceName,” or values for “deviceMetrics” and “userAgent.” Refer to Mobile Emulation for more information.
-- | -- | -- | --


<!--EndFragment-->
</body>
</html>

As I'm not English native speaker I was not aware that saying `values for “deviceMetrics” ` they had in the meaning that `deviceMetrics` is nested dictionary/object.

You can notice that on this page: 
https://sites.google.com/a/chromium.org/chromedriver/capabilities

that:

1. There is quite good documentation for: `perfLoggingPrefs object` 
2. Not so good documentation for: `mobileEmulation object`
3. And IMHO lack of documentation for: `deviceMetrics object`

For this reason I was not aware about that `ChromeOptions object` contains object nested in another object (subsequently nested dictionaries)

### Checklist
- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes
- [ ] Bugfix (change which fixes an issue)
- [x] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?
`_WD_CapabilitiesAdd()` can not create JSON structure for `deviceMetrics` object.

there was option to use:

```autoit
	_WD_CapabilitiesAdd("mobileEmulation", "deviceName", 'Nexus 5')
```

or
```autoit
	_WD_CapabilitiesAdd("mobileEmulation", "useragent", 'Mozilla/5.0 (Windows NT 10.0; Win' & StringReplace(@OSArch, 'X', '') & '; ' & @CPUArch & ') AppleWebKit/537.36 (KHTML, like Gecko) Chrome/' & _WD_GetBrowserVersion('chrome') & ' Safari/537.36')
````

but no possibilities to add  `deviceMetrics` capability.

### What is the new behavior?
With this changes (proposed in this PR), solution to this problem is following usage:
```autoit
_WD_CapabilitiesAdd("mobileEmulation>deviceMetrics", "width", 320)
_WD_CapabilitiesAdd("mobileEmulation>deviceMetrics", "height", 640)
_WD_CapabilitiesAdd("mobileEmulation>deviceMetrics", "pixelRatio", 3)
```

For example using `wd_demo.au3` with this modified function:
```autoit
Func SetupChrome($bHeadless)
	_WD_Option('Driver', 'chromedriver.exe')
	_WD_Option('Port', 9515)
	_WD_Option('DriverParams', '--verbose --log-path="' & @ScriptDir & '\chrome.log"')

;~ 	Local $sCapabilities = '{"capabilities": {"alwaysMatch": {"goog:chromeOptions": {"w3c": true, "excludeSwitches": [ "enable-automation"]}}}}'
	_WD_CapabilitiesStartup()
	_WD_CapabilitiesAdd('alwaysMatch', 'chrome')
	_WD_CapabilitiesAdd('w3c', True)
	_WD_CapabilitiesAdd('excludeSwitches', 'enable-automation')
	If $bHeadless Then _WD_CapabilitiesAdd('args', '--headless')
;~ 	_WD_CapabilitiesAdd("mobileEmulation", "deviceName", 'Nexus 5')
	_WD_CapabilitiesAdd("mobileEmulation", "useragent", 'Mozilla/5.0 (Windows NT 10.0; Win' & StringReplace(@OSArch, 'X', '') & '; ' & @CPUArch & ') AppleWebKit/537.36 (KHTML, like Gecko) Chrome/' & _WD_GetBrowserVersion('chrome') & ' Safari/537.36')
	_WD_CapabilitiesAdd("mobileEmulation>deviceMetrics", "width", 320)
	_WD_CapabilitiesAdd("mobileEmulation>deviceMetrics", "height", 640)
	_WD_CapabilitiesAdd("mobileEmulation>deviceMetrics", "pixelRatio", 3)

	_WD_CapabilitiesDump(@ScriptLineNumber) ; dump current Capabilities setting to console - only for testing in this demo
	Local $sCapabilities = _WD_CapabilitiesGet()
	Return $sCapabilities
EndFunc   ;==>SetupChrome
```

you can get such results:
```json
{
    "capabilities":{
        "alwaysMatch":{
            "goog:chromeOptions":{
                "w3c":true,
                "excludeSwitches":[
                    "enable-automation"
                ],
                "mobileEmulation":{
                    "useragent":"Mozilla\/5.0 (Windows NT 10.0; Win64; X64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/103.0.5060.134 Safari\/537.36",
                    "deviceMetrics":{
                        "width":320,
                        "height":640,
                        "pixelRatio":3
                    }
                }
            }
        }
    }
}
```
### Additional context
User asked for support here:
https://www.autoitscript.com/forum/topic/208563-help-needed-with-simple-workflow-for-webdriver-udf

### System under test
Google ChromeBrowser

![image](https://user-images.githubusercontent.com/11089482/181315473-8742a757-c56d-4dd8-9382-35b77081dc52.png)

### TODO
Check other Chromium based browser



