### PR TITLE
_WD_GetSession checking Browser with JavaScript

### DIFF
--- a/wd_core.au3
+++ b/wd_core.au3
@@ -302,9 +302,9 @@ EndFunc   ;==>_WD_Status
 ; Syntax ........: _WD_GetSession($sSession)
 ; Parameters ....: $sSession - Session ID from _WD_CreateSession
 ; Return values .: Success - Dictionary object with "sessionId" and "capabilities" items.
-;                  Failure - "" (empty string) and sets @error to $_WD_ERROR_Exception
+;                  Failure - "" (empty string) and sets @error to $_WD_ERROR_SessionInvalid
 ; Author ........: Danp2
-; Modified ......:
+; Modified ......: mLipok
 ; Remarks .......: The Get Session functionality was added and then removed from the W3C draft spec, so the code is commented
 ;                  until they determine how this should function. See w3c/webdriver@35df53a for details. Meanwhile, I temporarily
 ;                  changed the code to return the information that is available
@@ -314,8 +314,7 @@ EndFunc   ;==>_WD_Status
 ; ===============================================================================================================================
 Func _WD_GetSession($sSession)
 	Local Const $sFuncName = "_WD_GetSession"
-	Local $sResult
-	#forceref $sSession, $sFuncName
+	Local $iErr = $_WD_ERROR_Success, $sResult
 
 	#cs See remarks in header
 	Local $sResponse = __WD_Get($_WD_BASE_URL & ":" & $_WD_PORT & "/session/" & $sSession)
@@ -333,9 +332,15 @@ Func _WD_GetSession($sSession)
 	EndIf
 	#ce See remarks in header
 
-	$sResult = $_WD_SESSION_DETAILS
+	_WD_ExecuteScript($sSession, 'window') ; even empty page like a about:blank has a window
+	If @error Then ; if there is no window then something is wrong with session
+		$iErr = $_WD_ERROR_SessionInvalid
+	Else
+		$sResult = $_WD_SESSION_DETAILS
+	EndIf
 
-	Return SetError(__WD_Error($sFuncName, $_WD_ERROR_Success), 0, $sResult)
+	Local $sMessage = ($iErr) ? ("Check your session.") : ("")
+	Return SetError(__WD_Error($sFuncName, $iErr, $sMessage), 0, $sResult)
 EndFunc   ;==>_WD_GetSession
 
 ; #FUNCTION# ====================================================================================================================


### PR DESCRIPTION
## Pull request

### Proposed changes

As so far _WD_GetSession was not doing anything to tries check current real status of the session.
By using simple JS we can check if browser is responsible.
For now, that should be enough before the other issues are resolved:   See https://github.com/w3c/webdriver/commit/35df53a8a71500e264497f0cbda9f30a94e548cc for details.

### Checklist

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

- [ ] Bugfix (change which fixes an issue)
- [x] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

No way to check current session real status.

### What is the new behavior?
You can check if connection (a browser to be more precise) response to any action.
I know this is only work around.
But as for now it is a very useful workaround.

### Additional context
Tested with:
```autoit
Func UserTesting() ; here you can replace the code to test your stuff before you ask on the forum
	MsgBox(0, "", 'MANUALLY CLOSE YOUR BROWSER')
	Local $sResult = _WD_GetSession($sSession)
	If @error Then ConsoleWrite("! ---> @error=" & @error & "  @extended=" & @extended & _
			" : TESTING _WD_GetSession() = " & $sResult & @CRLF)
EndFunc   ;==>UserTesting
```

My inspiration was here:
https://github.com/Danp2/au3WebDriver/issues/63


### System under test
not related