### PR TITLE
UserTesting() session validation and extra space

### DIFF
--- a/wd_demo.au3
+++ b/wd_demo.au3
@@ -203,13 +203,11 @@ Func RunDemo($idDebugging, $idBrowsers, $idUpdate, $idHeadless, $idOutput)
 			ContinueLoop
 		EndIf
 
-		ConsoleWrite("+ wd_demo.au3: Running: " & $sDemoName & @CRLF)
 		_WD_CheckContext($sSession, False)
-		If @error Then ; return if session is NOT OK
-			ConsoleWrite("! ---> @error=" & @error & "  @extended=" & @extended & _
-					" : _WD_CheckContext reported a problem with the session" & @CRLF)
-			ContinueLoop
-		EndIf
+		$iError = @error
+		If @error Then ExitLoop ; return if session is NOT OK
+		
+		ConsoleWrite("+ wd_demo.au3: Running: " & $sDemoName & @CRLF)
 		If $aDemoSuite[$iIndex][2] Then
 			Call($sDemoName, $sBrowserName)
 		Else

--- a/wd_demo.au3
+++ b/wd_demo.au3
@@ -918,7 +918,15 @@ Func DemoStyles()
 
 EndFunc   ;==>DemoStyles
 
+#Region - UserTesting
 Func UserTesting() ; here you can replace the code to test your stuff before you ask on the forum
+	_WD_CheckContext($sSession, False)
+	If @error Then ; return if session is NOT OK
+		ConsoleWrite("! ---> @error=" & @error & "  @extended=" & @extended & _
+				" : _WD_CheckContext reported a problem with the session" & @CRLF)
+		Return
+	EndIf
+	
 	_WD_Navigate($sSession, 'https://www.google.com')
 	_WD_LoadWait($sSession)
 
@@ -929,6 +937,10 @@ Func UserTesting() ; here you can replace the code to test your stuff before you
 	_WD_WaitElement($sSession, $_WD_LOCATOR_ByCSSSelector, '#fake', 1000, 3000, $_WD_OPTION_NoMatch)
 ;~ 	Exit
 EndFunc   ;==>UserTesting
+
+; if necessary, add any additional function required for testing within this region here
+
+#EndRegion - UserTesting
 
 Func _USER_WD_Sleep($iDelay)
 	Local $hTimer = TimerInit() ; Begin the timer and store the handle in a variable.

--- a/wd_demo.au3
+++ b/wd_demo.au3
@@ -204,6 +204,12 @@ Func RunDemo($idDebugging, $idBrowsers, $idUpdate, $idHeadless, $idOutput)
 		EndIf
 
 		ConsoleWrite("+ wd_demo.au3: Running: " & $sDemoName & @CRLF)
+		_WD_CheckContext($sSession, False)
+		If @error Then ; return if session is NOT OK
+			ConsoleWrite("! ---> @error=" & @error & "  @extended=" & @extended & _
+					" : _WD_CheckContext reported a problem with the session" & @CRLF)
+			ContinueLoop
+		EndIf
 		If $aDemoSuite[$iIndex][2] Then
 			Call($sDemoName, $sBrowserName)
 		Else
@@ -920,13 +926,6 @@ EndFunc   ;==>DemoStyles
 
 #Region - UserTesting
 Func UserTesting() ; here you can replace the code to test your stuff before you ask on the forum
-	_WD_CheckContext($sSession, False)
-	If @error Then ; return if session is NOT OK
-		ConsoleWrite("! ---> @error=" & @error & "  @extended=" & @extended & _
-				" : _WD_CheckContext reported a problem with the session" & @CRLF)
-		Return
-	EndIf
-	
 	_WD_Navigate($sSession, 'https://www.google.com')
 	_WD_LoadWait($sSession)
 


### PR DESCRIPTION
## Pull request

### Proposed changes

I made FR here: https://github.com/Danp2/au3WebDriver/issues/354
And I realizie that I had to add new Function() that are subject to review.
The same situation may arise if someone wants to report a problem.
That's why I found the whole region useful for testing and additional commentary.

In addition, I found that just in case it would be good to add validation if the session is correct, as basically the whole demo does not use it, and in the case of `UserTesting` scripts it would be helpful.

### Checklist

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [ ] Bugfix (change which fixes an issue)
- [x] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [x] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?
no session validation
no additionall space where user should put speciall testing function

### What is the new behavior?
added session validtation
```autoit
	_WD_CheckContext($sSession, False)
	If @error Then ; return if session is NOT OK
		ConsoleWrite("! ---> @error=" & @error & "  @extended=" & @extended & _
				" : _WD_CheckContext reported a problem with the session" & @CRLF)
		Return
	EndIf
```

additional test space inside the region:
```autoit
#Region - UserTesting
....
#EndRegion - UserTesting
```

### Additional context

none

### System under test

not related
