### PR TITLE
_WD_FrameList

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ This au3WebDriver UDF (project) allows to interact with any browser that support
 | _WD_ElementStyle        | Set/Get element style property.                                                 |
 | _WD_FrameEnter          | Enter the specified frame.                                                      |
 | _WD_FrameLeave          | Leave the current frame, to its parent.                                         |
+| _WD_FrameList           | Retrieves a detailed list of the main document and all associated frames.       |
 | _WD_GetBrowserPath      | Retrieve path to browser executable from registry.                              |
 | _WD_GetBrowserVersion   | Get version number of specified browser.                                        |
 | _WD_GetDevicePixelRatio | Returns an integer indicating the DevicePixelRatio.                             |

--- a/wd_demo.au3
+++ b/wd_demo.au3
@@ -580,15 +580,18 @@ Func DemoFrames()
 	If @error Then Return SetError(@error, @extended)
 
 	Local $iFrameCount = _WD_GetFrameCount($sSession)
+	If @error Then Return SetError(@error, @extended)
 	ConsoleWrite("wd_demo.au3: (" & @ScriptLineNumber & ") : Frames=" & $iFrameCount & @CRLF)
 
 	$bIsWindowTop = _WD_IsWindowTop($sSession)
+	If @error Then Return SetError(@error, @extended)
 	; just after navigate current context should be on top level Window
 	ConsoleWrite("wd_demo.au3: (" & @ScriptLineNumber & ") : TopWindow = " & $bIsWindowTop & @CRLF)
 
 	$sElement = _WD_FindElement($sSession, $_WD_LOCATOR_ByXPath, "//iframe[@id='iframeResult']")
 	; changing context to first frame
 	_WD_FrameEnter($sSession, $sElement)
+	If @error Then Return SetError(@error, @extended)
 
 	$bIsWindowTop = _WD_IsWindowTop($sSession)
 	; after changing context to first frame the current context is not on top level Window
@@ -597,18 +600,94 @@ Func DemoFrames()
 	$sElement = _WD_FindElement($sSession, $_WD_LOCATOR_ByXPath, "//iframe")
 	; changing context to first sub frame
 	_WD_FrameEnter($sSession, $sElement)
+	If @error Then Return SetError(@error, @extended)
 
 	_WD_LinkClickByText($sSession, "Not Sure Where")
 
+	; Leaving sub frame
 	_WD_FrameLeave($sSession)
+	If @error Then Return SetError(@error, @extended)
+
 	$bIsWindowTop = _WD_IsWindowTop($sSession)
 	; after leaving sub frame, the current context is back to first frame but still is not on top level Window
 	ConsoleWrite("wd_demo.au3: (" & @ScriptLineNumber & ") : TopWindow = " & $bIsWindowTop & @CRLF)
 
+	; Leaving first frame
 	_WD_FrameLeave($sSession)
+	If @error Then Return SetError(@error, @extended)
+
 	$bIsWindowTop = _WD_IsWindowTop($sSession)
 	; after leaving first frame, the current context should back on top level Window
 	ConsoleWrite("wd_demo.au3: (" & @ScriptLineNumber & ") : TopWindow = " & $bIsWindowTop & @CRLF)
+
+	; now lets try to check frame list and using locations as path:
+	; go to website
+	_WD_Navigate($sSession, 'https://www.w3schools.com/tags/tryit.asp?filename=tryhtml_iframe')
+	_WD_LoadWait($sSession)
+
+	; Example 1 - from 'https://www.w3schools.com' get frame list as string
+	Local $sResult = _WD_FrameList($sSession, False)
+	#forceref $sResult
+	ConsoleWrite("! ---> @error=" & @error & "  @extended=" & @extended & " : Example 1" & @CRLF)
+	ConsoleWrite($sResult & @CRLF)
+
+	; Example 2 - from 'https://www.w3schools.com' get frame list as array, with HTML content of each document
+	Local $aFrameList = _WD_FrameList($sSession, True)
+	ConsoleWrite("! ---> @error=" & @error & "  @extended=" & @extended & " : Example 2" & @CRLF)
+	_ArrayDisplay($aFrameList, 'Example 2 - w3schools.com - get frame list as array, with HTML content of each document', 0, 0, Default, 'Absolute Identifiers > _WD_FrameEnter|Relative Identifiers > _WD_FrameEnter|IFRAME attributes|URL|Body ElementID')
+
+	; check if document context location is Top Window
+	ConsoleWrite("> " & @ScriptLineNumber & " IsWindowTop = " & _WD_IsWindowTop($sSession) & @CRLF)
+
+	; change document context location
+	_WD_FrameEnter($sSession, 'null/2/0')
+
+	; check if document context location is Top Window
+	ConsoleWrite("> " & @ScriptLineNumber & " IsWindowTop = " & _WD_IsWindowTop($sSession) & @CRLF)
+
+	; Example 3 - from 'https://www.w3schools.com' get frame list as array, while is current location is "null/2/0"
+	$aFrameList = _WD_FrameList($sSession, True)
+	ConsoleWrite("! ---> @error=" & @error & "  @extended=" & @extended & " : Example 3" & @CRLF)
+	_ArrayDisplay($aFrameList, 'Example 3 - w3schools.com - relative to "null/2/0"', 0, 0, Default, 'Absolute Identifiers > _WD_FrameEnter|Relative Identifiers > _WD_FrameEnter|IFRAME attributes|URL|Body ElementID')
+
+	; go to another website
+	_WD_Navigate($sSession, 'https://stackoverflow.com/questions/19669786/check-if-element-is-visible-in-dom')
+	_WD_LoadWait($sSession)
+
+	; Example 4 - from 'https://stackoverflow.com' get frame list as string
+	$sResult = _WD_FrameList($sSession, False)
+	ConsoleWrite("! ---> @error=" & @error & "  @extended=" & @extended & " : Example 4" & @CRLF)
+	ConsoleWrite($sResult & @CRLF)
+
+	; Example 5 - from 'https://stackoverflow.com' get frame list as array
+	$aFrameList = _WD_FrameList($sSession, True)
+	ConsoleWrite("! ---> @error=" & @error & "  @extended=" & @extended & " : Example 5" & @CRLF)
+	_ArrayDisplay($aFrameList, 'Example 5 - stackoverflow.com - get frame list as array', 0, 0, Default, 'Absolute Identifiers > _WD_FrameEnter|Relative Identifiers > _WD_FrameEnter|IFRAME attributes|URL|Body ElementID')
+
+	; check if document context location is Top Window
+	ConsoleWrite("> " & @ScriptLineNumber & " IsWindowTop = " & _WD_IsWindowTop($sSession) & @CRLF)
+
+	; change document context location
+	_WD_FrameEnter($sSession, 'null/2')
+
+	; check if document context location is Top Window
+	ConsoleWrite("> " & @ScriptLineNumber & " IsWindowTop = " & _WD_IsWindowTop($sSession) & @CRLF)
+
+	; Example 6v1 - from 'https://stackoverflow.com' get frame list as array, while is current location is "null/2"
+	$aFrameList = _WD_FrameList($sSession, True)
+	ConsoleWrite("! ---> @error=" & @error & "  @extended=" & @extended & " : Example 6v1" & @CRLF)
+	_ArrayDisplay($aFrameList, 'Example 6v1 - stackoverflow.com - relative to "null/2"', 0, 0, Default, 'Absolute Identifiers > _WD_FrameEnter|Relative Identifiers > _WD_FrameEnter|IFRAME attributes|URL|Body ElementID')
+
+	; check if document context location is Top Window
+	ConsoleWrite("> " & @ScriptLineNumber & " IsWindowTop = " & _WD_IsWindowTop($sSession) & @CRLF)
+
+	; Example 6v2 - from 'https://stackoverflow.com' get frame list as array, check if it is still relative to the same location as it was before recent _WD_FrameList() was used - still should be "null/2"
+	$aFrameList = _WD_FrameList($sSession, True)
+	ConsoleWrite("! ---> @error=" & @error & "  @extended=" & @extended & " : Example 6v2" & @CRLF)
+	_ArrayDisplay($aFrameList, 'Example 6v2 - stackoverflow.com - check if it is still relative to "null/2"', 0, 0, Default, 'Absolute Identifiers > _WD_FrameEnter|Relative Identifiers > _WD_FrameEnter|IFRAME attributes|URL|Body ElementID')
+
+	; check if document context location is Top Window
+	ConsoleWrite("> " & @ScriptLineNumber & " IsWindowTop = " & _WD_IsWindowTop($sSession) & @CRLF)
 
 EndFunc   ;==>DemoFrames
 

--- a/wd_demo.au3
+++ b/wd_demo.au3
@@ -631,7 +631,7 @@ Func DemoFrames()
 	ConsoleWrite("! ---> @error=" & @error & "  @extended=" & @extended & " : Example 1" & @CRLF)
 	ConsoleWrite($sResult & @CRLF)
 
-	; Example 2 - from 'https://www.w3schools.com' get frame list as array, with HTML content of each document
+	; Example 2 - from 'https://www.w3schools.com' get frame list as array
 	Local $aFrameList = _WD_FrameList($sSession, True)
 	ConsoleWrite("! ---> @error=" & @error & "  @extended=" & @extended & " : Example 2" & @CRLF)
 	_ArrayDisplay($aFrameList, 'Example 2 - w3schools.com - get frame list as array, with HTML content of each document', 0, 0, Default, 'Absolute Identifiers > _WD_FrameEnter|Relative Identifiers > _WD_FrameEnter|IFRAME attributes|URL|Body ElementID')
@@ -640,15 +640,15 @@ Func DemoFrames()
 	ConsoleWrite("> " & @ScriptLineNumber & " IsWindowTop = " & _WD_IsWindowTop($sSession) & @CRLF)
 
 	; change document context location
-	_WD_FrameEnter($sSession, 'null/2/0')
+	_WD_FrameEnter($sSession, 'null/0')
 
 	; check if document context location is Top Window
 	ConsoleWrite("> " & @ScriptLineNumber & " IsWindowTop = " & _WD_IsWindowTop($sSession) & @CRLF)
 
-	; Example 3 - from 'https://www.w3schools.com' get frame list as array, while is current location is "null/2/0"
+	; Example 3 - from 'https://www.w3schools.com' get frame list as array, while current location is "null/0"
 	$aFrameList = _WD_FrameList($sSession, True)
 	ConsoleWrite("! ---> @error=" & @error & "  @extended=" & @extended & " : Example 3" & @CRLF)
-	_ArrayDisplay($aFrameList, 'Example 3 - w3schools.com - relative to "null/2/0"', 0, 0, Default, 'Absolute Identifiers > _WD_FrameEnter|Relative Identifiers > _WD_FrameEnter|IFRAME attributes|URL|Body ElementID')
+	_ArrayDisplay($aFrameList, 'Example 3 - w3schools.com - relative to "null/0"', 0, 0, Default, 'Absolute Identifiers > _WD_FrameEnter|Relative Identifiers > _WD_FrameEnter|IFRAME attributes|URL|Body ElementID')
 
 	; go to another website
 	_WD_Navigate($sSession, 'https://stackoverflow.com/questions/19669786/check-if-element-is-visible-in-dom')

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -79,7 +79,7 @@ Global Enum _
 Global Enum _
 		$_WD_FRAMELIST_Absolute = 0, _
 		$_WD_FRAMELIST_Relative = 1, _
-		$_WD_FRAMELIST_Atributes = 2, _
+		$_WD_FRAMELIST_Attributes = 2, _
 		$_WD_FRAMELIST_URL = 3, _
 		$_WD_FRAMELIST_BodyID = 4, _
 		$_WD_FRAMELIST_HTML = 5
@@ -685,10 +685,10 @@ EndFunc   ;==>_WD_FrameLeave
 ; Description ...: Retrieves a detailed list of the main document and all associated frames
 ; Syntax ........: _WD_FrameList($sSession[, $bReturnAsArray = True[, $sFilter = ''[, $bReturnHTML = False]]])
 ; Parameters ....: $sSession            - Session ID from _WD_CreateSession
-;                  $bReturnAsArray      - By default on True function will return array, other wise string
-;                  $sFilter             - RegExp pattern to check HTML from "document.body". If used it returns only frames with desired HTML content
-;                  $bReturnHTML         - On true function will return frame document HTML source
-; Return values .: Success - 2D array (with 6 cols) or string ( delimeted with | and @CRLF )
+;                  $bReturnAsArray      - [optional] Return result as array? Default is True.
+;                  $sFilter             - [optional] RegExp pattern to filter frames with their HTML content. Default is ''.
+;                  $bReturnHTML         - [optional] Return frame document's HTML source? Default is False.
+; Return values .: Success - 2D array (with 6 cols) or string ( delimited with | and @CRLF )
 ;                  Failure - "" (empty string) and sets @error to one of the following values:
 ;                  - $_WD_ERROR_GeneralError
 ;                  - $_WD_ERROR_Exception
@@ -696,7 +696,7 @@ EndFunc   ;==>_WD_FrameLeave
 ;                  - $_WD_ERROR_NotFound
 ; Author ........: mLipok
 ; Modified ......: Danp2
-; Remarks .......: using $bReturnHTML will always return array
+; Remarks .......: Always returns an array when $bReturnHTML is True.
 ; Related .......: _WD_GetFrameCount, _WD_FrameEnter, _WD_FrameLeave
 ; Link ..........:
 ; Example .......: No
@@ -753,7 +753,7 @@ Func _WD_FrameList($sSession, $bReturnAsArray = True, $sFilter = '', $bReturnHTM
 			$iErr = $_WD_ERROR_NotFound
 			$a_Result = ''
 		Else
-			If $bReturnHTML = False Then
+			If Not $bReturnHTML Then
 				; cleanup HTML
 				For $i = 0 To UBound($a_Result) - 1
 					$a_Result[$i][5] = ''

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -782,6 +782,12 @@ Func __WD_FrameList_Internal($sSession, $sLevel, $sFrameAttributes)
 	Local $iErr = $_WD_ERROR_Success
 	Local $vResult = '', $s_URL = '', $sMessage = ''
 
+	; save current DEBUG level
+	Local $_WD_DEBUG_Saved = $_WD_DEBUG
+
+	; Prevent logging multiple errors from __WD_FrameList_Internal if not in Full debug mode - https://github.com/Danp2/au3WebDriver/pull/362#issuecomment-1220962556
+	If $_WD_DEBUG <> $_WD_DEBUG_Full Then $_WD_DEBUG = $_WD_DEBUG_None
+
 	_WD_FrameEnter($sSession, $sLevel)
 	$iErr = @error
 
@@ -831,6 +837,8 @@ Func __WD_FrameList_Internal($sSession, $sLevel, $sFrameAttributes)
 		EndIf
 	EndIf
 	If $iErr Then $iErr = $_WD_ERROR_Exception
+
+	$_WD_DEBUG = $_WD_DEBUG_Saved ; restore DEBUG level
 
 	$sMessage = ($sMessage And $_WD_DEBUG > $_WD_DEBUG_Error) ? (' Information: ' & $sMessage) : ("")
 	Return SetError(__WD_Error($sFuncName, $iErr, $sParameters & $sMessage), 0, $vResult)

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -638,8 +638,8 @@ EndFunc   ;==>_WD_FrameLeave
 
 ; #FUNCTION# ====================================================================================================================
 ; Name ..........: _WD_FrameList
-; Description ...: list detailed information about frames possible to use ("window.top" and all frames)
-; Syntax ........: _WD_FrameList(Const $sSession[, Const $bReturnAsArray = True[, Const $sFilter = ''[, Const $bReturnHTML = False]]])
+; Description ...: Retrieves a detailed list of the main document and all associated frames
+; Syntax ........: _WD_FrameList($sSession[, $bReturnAsArray = True[, $sFilter = ''[, $bReturnHTML = False]]])
 ; Parameters ....: $sSession            - Session ID from _WD_CreateSession
 ;                  $bReturnAsArray      - By default on True function will return array, other wise string
 ;                  $sFilter             - RegExp pattern to check HTML from "document.body". If used it returns only frames with desired HTML content
@@ -651,13 +651,13 @@ EndFunc   ;==>_WD_FrameLeave
 ;                  - $_WD_ERROR_InvalidExpression
 ;                  - $_WD_ERROR_NotFound
 ; Author ........: mLipok
-; Modified ......:
+; Modified ......: Danp2
 ; Remarks .......: using $bReturnHTML will always return array
 ; Related .......: _WD_GetFrameCount, _WD_FrameEnter, _WD_FrameLeave
 ; Link ..........:
 ; Example .......: No
 ; ===============================================================================================================================
-Func _WD_FrameList(Const $sSession, Const $bReturnAsArray = True, Const $sFilter = '', Const $bReturnHTML = False)
+Func _WD_FrameList($sSession, $bReturnAsArray = True, $sFilter = '', $bReturnHTML = False)
 	Local Const $sFuncName = "_WD_FrameList"
 	Local Const $sParameters = 'Parameters:    ReturnAsArray=' & $bReturnAsArray & '   Filter=' & $sFilter & '   ReturnHTML=' & $bReturnHTML
 	Local Const $bReturnHTML_Internally = ($bReturnHTML Or $sFilter <> '')
@@ -756,7 +756,7 @@ EndFunc   ;==>_WD_FrameList
 ;                  - $_WD_ERROR_Exception
 ;                  - $_WD_ERROR_InvalidExpression
 ; Author ........: mLipok
-; Modified ......:
+; Modified ......: Danp2
 ; Remarks .......:
 ; Related .......: _WD_FrameList, _WD_GetFrameCount, _WD_FrameEnter, _WD_FrameLeave
 ; Link ..........:

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -819,6 +819,7 @@ Func __WD_FrameList_Internal(Const $sSession, Const $sLevel, $sFrameAttributes, 
 				If @error Then
 					$sMessage = 'Error occured on "' & $sLevel & '" level when trying to check atributes child frames #' & $iFrame
 				Else
+					$sFrameAttributes = StringRegExpReplace($sFrameAttributes, '\R', '')
 					$vResult &= __WD_FrameList_Internal($sSession, $sLevel & '/' & $iFrame, $sFrameAttributes, $bReturnHTML)
 					$iErr = @error
 					If Not @error Then

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -692,15 +692,15 @@ Func _WD_FrameList($sSession, $bReturnAsArray = True, $sFilter = '', $bReturnHTM
 		; check the array backwards as elements may be removed
 		For $i = UBound($a_Result) - 1 To 0 Step -1
 			; find "calling frame" location - set $sStartLocation
-			If $a_Result[$i][4] = $sElement_CallingFrameBody Then $sStartLocation = $a_Result[$i][0]
+			If $a_Result[$i][$_WD_FRAMELIST_BodyID] = $sElement_CallingFrameBody Then $sStartLocation = $a_Result[$i][$_WD_FRAMELIST_Absolute]
 
 			; recalculate locations from absolute path on COL0 to relative path on COL1
-			$a_Result[$i][1] = StringRegExpReplace($a_Result[$i][0], '\A' & $sStartLocation & '\/?', '')
+			$a_Result[$i][$_WD_FRAMELIST_Relative] = StringRegExpReplace($a_Result[$i][$_WD_FRAMELIST_Absolute], '\A' & $sStartLocation & '\/?', '')
 
 			; apply filter - delete frames that HTML content string do not fits a given regular expression pattern
 			If $sFilter <> '' Then
-				; check $s_HTML content :  $a_Result[$i][5]
-				If StringRegExp(BinaryToString($a_Result[$i][5], $SB_UTF8), $sFilter, $STR_REGEXPMATCH) = 1 Then
+				; check $s_HTML content
+				If StringRegExp(BinaryToString($a_Result[$i][$_WD_FRAMELIST_HTML], $SB_UTF8), $sFilter, $STR_REGEXPMATCH) = 1 Then
 					; do nothing keeping current row of $a_Result[$i][....]
 				ElseIf @error = 2 Then ; @error StringRegExp : Bad pattern. @extended = offset of error in pattern
 					$iExt = @extended

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -743,7 +743,7 @@ Func _WD_FrameList($sSession, $bReturnAsArray = True)
 			$vResult = _ArrayToString($a_Result)
 			If @error Then
 				$iErr = $_WD_ERROR_RetValue
-				$sMessage &= ' ArrayToSring conversion failed'
+				$sMessage &= ' ArrayToString conversion failed'
 				$vResult = ''
 			EndIf
 		EndIf

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -726,7 +726,9 @@ Func _WD_FrameList($sSession, $bReturnAsArray = True, $sFilter = '', $bReturnHTM
 		_ArrayAdd($a_Result, $vResult)
 
 		; check the array backwards as elements may be removed
+		Local $bWasDeleted = False
 		For $i = UBound($a_Result) - 1 To 0 Step -1
+			$bWasDeleted = False
 			; find "calling frame" location - set $sStartLocation
 			If $a_Result[$i][$_WD_FRAMELIST_BodyID] = $sElement_CallingFrameBody Then $sStartLocation = $a_Result[$i][$_WD_FRAMELIST_Absolute]
 
@@ -749,11 +751,12 @@ Func _WD_FrameList($sSession, $bReturnAsArray = True, $sFilter = '', $bReturnHTM
 					ExitLoop
 				Else ; StringRegExp = 0 no MATCH
 					_ArrayDelete($a_Result, $i)
+					$bWasDeleted = True
 				EndIf
 			EndIf
 
 			; cleanup HTML
-			If Not $bReturnHTML Then
+			If Not ($bWasDeleted Or $bReturnHTML) Then
 				$a_Result[$i][$_WD_FRAMELIST_HTML] = ''
 			EndIf
 		Next

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -755,7 +755,7 @@ Func _WD_FrameList($sSession, $bReturnAsArray = True)
 
 	#EndRegion - post processing
 
-	$sMessage = ($sMessage And $_WD_DEBUG = $_WD_DEBUG_Full) ? (' Information: ' & $sMessage) : ("")
+	$sMessage = ($sMessage And $_WD_DEBUG > $_WD_DEBUG_Error) ? (' Information: ' & $sMessage) : ("")
 	Return SetError(__WD_Error($sFuncName, $iErr, $sParameters & $sMessage), 0, $vResult)
 EndFunc   ;==>_WD_FrameList
 
@@ -832,7 +832,7 @@ Func __WD_FrameList_Internal($sSession, $sLevel, $sFrameAttributes)
 	EndIf
 	If $iErr Then $iErr = $_WD_ERROR_Exception
 
-	$sMessage = ($sMessage And $_WD_DEBUG = $_WD_DEBUG_Full) ? (' Information: ' & $sMessage) : ("")
+	$sMessage = ($sMessage And $_WD_DEBUG > $_WD_DEBUG_Error) ? (' Information: ' & $sMessage) : ("")
 	Return SetError(__WD_Error($sFuncName, $iErr, $sParameters & $sMessage), 0, $vResult)
 EndFunc   ;==>__WD_FrameList_Internal
 

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -741,7 +741,7 @@ Func _WD_FrameList($sSession, $bReturnAsArray = True, $sFilter = '', $bReturnHTM
 		$iErr = @error
 	EndIf
 
-	If $iErr And $iErr <> $_WD_ERROR_InvalidExpression Then
+	If $sStartLocation = '' Or $iErr Then
 		$sMessage = 'Was not able to check / back to "calling frame"'
 	EndIf
 

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -798,8 +798,8 @@ Func __WD_FrameList_Internal($sSession, $sLevel, $sFrameAttributes, $_WD_DEBUG_C
 		$sMessage = 'Error occured on "' & $sLevel & '" level when trying to entering frame'
 	Else
 		_WD_LoadWait($sSession, 100, 1000)
-		If 0 And @error Then ; intentionally do not check for error here, for details look at: https://github.com/Danp2/au3WebDriver/pull/362#issuecomment-1225512052
-			; $sMessage = 'Error occured on "' & $sLevel & '" level when waiting for a browser page load to complete'
+		If @error And @error <> $_WD_ERROR_Timeout Then
+			$sMessage = 'Error occured on "' & $sLevel & '" level when waiting for a browser page load to complete'
 		Else
 			Local $sCurrentBody_ElementID = _WD_ExecuteScript($sSession, "return window.document.body;", Default, Default, $_WD_JSON_Element)
 			$iErr = @error

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -82,7 +82,7 @@ Global Enum _
 		$_WD_FRAMELIST_Atributes = 2, _
 		$_WD_FRAMELIST_URL = 3, _
 		$_WD_FRAMELIST_BodyID = 4, _
-		$_WD_FRAMELIST_HTML =
+		$_WD_FRAMELIST_HTML = 5
 
 #EndRegion Global Constants
 

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -793,7 +793,6 @@ Func __WD_FrameList_Internal($sSession, $sLevel, $sFrameAttributes, $_WD_DEBUG_C
 	Local $vResult = '', $s_URL = '', $sMessage = ''
 
 	_WD_FrameEnter($sSession, $sLevel)
-	If $sLevel = 'null/3' Then SetError($_WD_ERROR_Exception)
 	$iErr = @error
 	If @error Then
 		$sMessage = 'Error occured on "' & $sLevel & '" level when trying to entering frame'

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -692,7 +692,7 @@ EndFunc   ;==>_WD_FrameLeave
 ;                  - $_WD_ERROR_RetValue
 ; Author ........: mLipok
 ; Modified ......: Danp2
-; Remarks .......:
+; Remarks .......: The list of frames can depend on many factors, including geolocation, as well as problems with the local Internet
 ; Related .......: _WD_GetFrameCount, _WD_FrameEnter, _WD_FrameLeave
 ; Link ..........:
 ; Example .......: No
@@ -797,10 +797,9 @@ Func __WD_FrameList_Internal($sSession, $sLevel, $sFrameAttributes, $_WD_DEBUG_C
 	If @error Then
 		$sMessage = 'Error occured on "' & $sLevel & '" level when trying to entering frame'
 	Else
-		_WD_LoadWait($sSession, 10, 30 * 1000)
-		$iErr = @error
-		If @error Then
-			$sMessage = 'Error occured on "' & $sLevel & '" level when waiting for a browser page load to complete'
+		_WD_LoadWait($sSession, 100, 1000)
+		If 0 And @error Then ; intentionally do not check for error here, for details look at: https://github.com/Danp2/au3WebDriver/pull/362#issuecomment-1225512052
+			; $sMessage = 'Error occured on "' & $sLevel & '" level when waiting for a browser page load to complete'
 		Else
 			Local $sCurrentBody_ElementID = _WD_ExecuteScript($sSession, "return window.document.body;", Default, Default, $_WD_JSON_Element)
 			$iErr = @error

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -76,6 +76,14 @@ Global Enum _
 		$_WD_STORAGE_Local = 0, _
 		$_WD_STORAGE_Session = 1
 		
+Global Enum _
+		$_WD_FRAMELIST_Absolute = 0, _
+		$_WD_FRAMELIST_Relative = 1, _
+		$_WD_FRAMELIST_Atributes = 2, _
+		$_WD_FRAMELIST_URL = 3, _
+		$_WD_FRAMELIST_BodyID = 4, _
+		$_WD_FRAMELIST_HTML =
+
 #EndRegion Global Constants
 
 ; #FUNCTION# ====================================================================================================================

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -733,7 +733,11 @@ Func _WD_FrameList($sSession, $bReturnAsArray = True)
 			$vResult = $a_Result
 		Else
 			$vResult = _ArrayToString($a_Result)
-			If @error Then $vResult = ''
+			If @error Then
+				$iErr = $_WD_ERROR_RetValue
+				$sMessage &= ' ArrayToSring conversion failed'
+				$vResult = ''
+			EndIf
 		EndIf
 
 	EndIf
@@ -744,8 +748,8 @@ Func _WD_FrameList($sSession, $bReturnAsArray = True)
 		$iErr = @error
 	EndIf
 
-	If $sStartLocation = '' Or $iErr Then
-		$sMessage = ' Was not able to check / back to "calling frame"'
+	If $sStartLocation = '' Or ($iErr And $iErr <> $_WD_ERROR_RetValue) Then
+		$sMessage &= ' Was not able to check / back to "calling frame"'
 	EndIf
 
 	#EndRegion - post processing

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -797,17 +797,23 @@ Func __WD_FrameList_Internal($sSession, $sLevel, $sFrameAttributes, $_WD_DEBUG_C
 	If @error Then
 		$sMessage = 'Error occured on "' & $sLevel & '" level when trying to entering frame'
 	Else
-		Local $sCurrentBody_ElementID = _WD_ExecuteScript($sSession, "return window.document.body;", Default, Default, $_WD_JSON_Element)
+		_WD_LoadWait($sSession, 10)
 		$iErr = @error
 		If @error Then
-			$sMessage = 'Error occured on "' & $sLevel & '" level when checking "document.body" ElementID'
+			$sMessage = 'Error occured on "' & $sLevel & '" level when waiting for a browser page load to complete'
 		Else
-			$s_URL = _WD_ExecuteScript($sSession, "return window.location.href", Default, Default, $_WD_JSON_Value)
+			Local $sCurrentBody_ElementID = _WD_ExecuteScript($sSession, "return window.document.body;", Default, Default, $_WD_JSON_Element)
 			$iErr = @error
 			If @error Then
-				$sMessage = 'Error occured on "' & $sLevel & '" level when checking URL'
+				$sMessage = 'Error occured on "' & $sLevel & '" level when checking "document.body" ElementID'
 			Else
-				$vResult = $sLevel & '|' & $sLevel & '|' & $sFrameAttributes & '|' & $s_URL & '|' & $sCurrentBody_ElementID & @CRLF
+				$s_URL = _WD_ExecuteScript($sSession, "return window.location.href", Default, Default, $_WD_JSON_Value)
+				$iErr = @error
+				If @error Then
+					$sMessage = 'Error occured on "' & $sLevel & '" level when checking URL'
+				Else
+					$vResult = $sLevel & '|' & $sLevel & '|' & $sFrameAttributes & '|' & $s_URL & '|' & $sCurrentBody_ElementID & @CRLF
+				EndIf
 			EndIf
 		EndIf
 	EndIf

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -689,6 +689,7 @@ EndFunc   ;==>_WD_FrameLeave
 ;                  Failure - "" (empty string) and sets @error to one of the following values:
 ;                  - $_WD_ERROR_GeneralError
 ;                  - $_WD_ERROR_Exception
+;                  - $_WD_ERROR_RetValue
 ; Author ........: mLipok
 ; Modified ......: Danp2
 ; Remarks .......:

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -798,6 +798,7 @@ Func __WD_FrameList_Internal($sSession, $sLevel, $sFrameAttributes, $_WD_DEBUG_C
 		$sMessage = 'Error occured on "' & $sLevel & '" level when trying to entering frame'
 	Else
 		_WD_LoadWait($sSession, 100, 1000)
+		$iErr = @error
 		If @error And @error <> $_WD_ERROR_Timeout Then
 			$sMessage = 'Error occured on "' & $sLevel & '" level when waiting for a browser page load to complete'
 		Else

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -827,7 +827,6 @@ Func __WD_FrameList_Internal($sSession, $sLevel, $sFrameAttributes, $_WD_DEBUG_C
 				Else
 					$sFrameAttributes = StringRegExpReplace($sFrameAttributes, '\R', '')
 					$vResult &= __WD_FrameList_Internal($sSession, $sLevel & '/' & $iFrame, $sFrameAttributes, $_WD_DEBUG_Calling)
-					$iTemp = @error
 					$iErr = @error
 					If Not @error Then
 						_WD_FrameLeave($sSession)

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -797,7 +797,7 @@ Func __WD_FrameList_Internal($sSession, $sLevel, $sFrameAttributes, $_WD_DEBUG_C
 	If @error Then
 		$sMessage = 'Error occured on "' & $sLevel & '" level when trying to entering frame'
 	Else
-		_WD_LoadWait($sSession, 10)
+		_WD_LoadWait($sSession, 10, 30 * 1000)
 		$iErr = @error
 		If @error Then
 			$sMessage = 'Error occured on "' & $sLevel & '" level when waiting for a browser page load to complete'

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -685,7 +685,7 @@ EndFunc   ;==>_WD_FrameLeave
 ; Syntax ........: _WD_FrameList($sSession[, $bReturnAsArray = True])
 ; Parameters ....: $sSession            - Session ID from _WD_CreateSession
 ;                  $bReturnAsArray      - [optional] Return result as array? Default is True.
-; Return values .: Success - 2D array (with 5 cols) or string ( delimeted with | and @CRLF )
+; Return values .: Success - 2D array (with 5 cols) or string ( delimited with | and @CRLF )
 ;                  Failure - "" (empty string) and sets @error to one of the following values:
 ;                  - $_WD_ERROR_GeneralError
 ;                  - $_WD_ERROR_Exception


### PR DESCRIPTION
## Pull request

### Proposed changes

was discussed here:
https://github.com/Danp2/au3WebDriver/issues/354

### Checklist

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

- [ ] Bugfix (change which fixes an issue)
- [x] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

no way to list frames list

### What is the new behavior?

it is easy with `_WD_FrameList`

### Additional context
https://github.com/Danp2/au3WebDriver/issues/354#issuecomment-1203042673

can be tested with:
```autoit
Func UserTesting() ; here you can replace the code to test your stuff before you ask on the forum

	_WD_Navigate($sSession, 'https://www.w3schools.com/tags/tryit.asp?filename=tryhtml_iframe')
	_WD_LoadWait($sSession)

	; Example 1 - from 'https://www.w3schools.com' get frame list as string
	ConsoleWrite(_WD_FrameList($sSession,  False) & @CRLF)

	; Example 2 - from 'https://www.w3schools.com' get frame list as array, with HTML content of each document
	Local $aFrameList = _WD_FrameList($sSession,  True, '', True)
	_ArrayDisplay($aFrameList, 'Example 2', 0, 0, Default, 'Absolute Identifiers > _WD_FrameEnter|Relative Identifiers > _WD_FrameEnter|IFRAME attributes|URL|Body ElementID|HTML')


	_WD_FrameEnter($sSession, 2)
	_WD_FrameEnter($sSession, 0)
	; Example 3 - from 'https://www.w3schools.com' get frame list as array, with relative location
	$aFrameList = _WD_FrameList($sSession, True, '', False)
	_ArrayDisplay($aFrameList, 'Example 3', 0, 0, Default, 'Absolute Identifiers > _WD_FrameEnter|Relative Identifiers > _WD_FrameEnter|IFRAME attributes|URL|Body ElementID|HTML')

	_WD_Navigate($sSession, 'https://stackoverflow.com/questions/19669786/check-if-element-is-visible-in-dom')
	_WD_LoadWait($sSession)

	; Example 4 - from 'https://stackoverflow.com' get frame list as string
	ConsoleWrite(_WD_FrameList($sSession,  False) & @CRLF)

	; Example 5 - from 'https://stackoverflow.com' get frame list as array
	#TODO this following line - NOT WORKS - should be checked
;~ 	$aFrameList = _WD_FrameList($sSession, True)
	$aFrameList = _WD_FrameList($sSession,  True, '', False)
	_ArrayDisplay($aFrameList, 'Example 5', 0, 0, Default, 'Absolute Identifiers > _WD_FrameEnter|Relative Identifiers > _WD_FrameEnter|IFRAME attributes|URL|Body ElementID|HTML')

	; Example 6 - from 'https://stackoverflow.com' get frame list as array - but only this one which contain id="question-header"
	$aFrameList = _WD_FrameList($sSession,  True, '(?i)id=.question-header.')
	_ArrayDisplay($aFrameList, 'Example 6', 0, 0, Default, 'Absolute Identifiers > _WD_FrameEnter|Relative Identifiers > _WD_FrameEnter|IFRAME attributes|URL|Body ElementID|HTML')

EndFunc   ;==>UserTesting
```

![image](https://user-images.githubusercontent.com/11089482/182446618-ebd5140e-4578-4920-90a6-888c3381e355.png)

### System under test
not related

