### PR TITLE
_WD_FrameEnter($sSession, 'null/2/0') - path support

### DIFF
--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -550,7 +550,8 @@ EndFunc   ;==>_WD_IsWindowTop
 ; ===============================================================================================================================
 Func _WD_FrameEnter($sSession, $vIdentifier)
 	Local Const $sFuncName = "_WD_FrameEnter"
-	Local Const $sParameters = 'Parameters:    Identifier=' & $vIdentifier
+	Local Const $bIsIdentifierNull = (IsKeyword($vIdentifier) = $KEYWORD_NULL)
+	Local Const $sParameters = 'Parameters:    Identifier=' & ($bIsIdentifierNull ? "Null" : $bIsIdentifierNull)
 	Local $sOption, $sValue, $sResponse, $oJSON, $sMessage = ''
 	Local $iErr = $_WD_ERROR_Success
 
@@ -572,7 +573,7 @@ Func _WD_FrameEnter($sSession, $vIdentifier)
 		Next
 		If $i > $aIdentifiers[0] Then $i = $aIdentifiers[0]
 		If $iErr Then $sMessage = ' Error on ID#' & $i
-	ElseIf (IsKeyword($vIdentifier) = $KEYWORD_NULL) Then
+	ElseIf $bIsIdentifierNull Then
 		$sOption = '{"id":null}'
 	ElseIf IsInt($vIdentifier) Then
 		$sOption = '{"id":' & $vIdentifier & '}'

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -560,7 +560,7 @@ Func _WD_FrameEnter($sSession, $vIdentifier)
 	Local $iErr = $_WD_ERROR_Success
 
 	;*** Encapsulate the value if it's an integer, assuming that it's supposed to be an Index, not ID attrib value.
-	Local Const $bIdentifierAsPath = ((StringRegExp($vIdentifier, '(?i)\A(Null|\d+)(\/)([\d\/]*\d)\Z', $STR_REGEXPMATCH) = 1) And (StringRegExp($vIdentifier, '\/{2,}', $STR_REGEXPMATCH) = 0)) ; must start with null or digit, must have at least one slash (may have many slashes but should not be followed one per other), must end with digit
+	Local Const $bIdentifierAsPath = StringRegExp($vIdentifier, "(?i)\A(?:Null|\d+)(?:\/\d+)+\Z", $STR_REGEXPMATCH) ; must start with null or digit, must have at least one slash (may have many slashes but should not be followed one per other), must end with digit
 	If $bIdentifierAsPath Then
 		; will be processed below
 	ElseIf $bIsIdentifierNull Then

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -543,10 +543,12 @@ EndFunc   ;==>_WD_IsWindowTop
 ;                  |String  - Element ID from _WD_FindElement or path like 'null/2/0'
 ;                  |Integer - 0-based index of frames
 ; Return values .: Success - True.
-;                  Failure - WD Response error message (E.g. "no such frame") and sets @error to $_WD_ERROR_Exception or $_WD_ERROR_InvalidArgue
+;                  Failure - WD Response error message (E.g. "no such frame") and sets @error to one of the following values:
+;                  - $_WD_ERROR_Exception
+;                  - $_WD_ERROR_InvalidArgue
 ; Author ........: Decibel
 ; Modified ......: Danp2, mLipok, jchd
-; Remarks .......: You can drill-down into nested frames by calling this function repeatedly with the correct parameters or use path like 'null/2/0'
+; Remarks .......: You can drill-down into nested frames by calling this function repeatedly or use identifier like 'null/2/0'
 ; Related .......: _WD_Window, _WD_LastHTTPResult
 ; Link ..........:
 ; Example .......: No
@@ -559,8 +561,9 @@ Func _WD_FrameEnter($sSession, $vIdentifier)
 	Local $sValue, $sMessage = '', $sOption, $sResponse, $oJSON
 	Local $iErr = $_WD_ERROR_Success
 
-	;*** Encapsulate the value if it's an integer, assuming that it's supposed to be an Index, not ID attrib value.
-	Local Const $bIdentifierAsPath = StringRegExp($vIdentifier, "(?i)\A(?:Null|\d+)(?:\/\d+)+\Z", $STR_REGEXPMATCH) ; must start with null or digit, must have at least one slash (may have many slashes but should not be followed one per other), must end with digit
+	; must start with null or digit, must have at least one slash (may have many slashes but should not be followed one per other), must end with digit	
+	Local Const $bIdentifierAsPath = StringRegExp($vIdentifier, "(?i)\A(?:Null|\d+)(?:\/\d+)+\Z", $STR_REGEXPMATCH) 
+
 	If $bIdentifierAsPath Then
 		; will be processed below
 	ElseIf $bIsIdentifierNull Then

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -558,17 +558,14 @@ Func _WD_FrameEnter($sSession, $vIdentifier)
 	Local $aIdentifiers = StringSplit($vIdentifier, '/')
 	Local $bIdentifierAsPath = ($aIdentifiers[0] > 1)
 	If $bIdentifierAsPath Then
-;~ 		_ArrayDisplay($aIdentifiers, $vIdentifier & ' >>> $aIdentifiers')
 		For $i = 1 To $aIdentifiers[0]
 			If $aIdentifiers[$i] = 'null' Then
-;~ 				MsgBox(0, "$bIdentifierAsPath", @ScriptLineNumber)
-				$aIdentifiers[$i] = Null
+				_WD_FrameEnter($sSession, Null)
+				$iErr = @error
 			ElseIf StringIsDigit($aIdentifiers[$i]) And IsInt(Number($aIdentifiers[$i])) Then
 				_WD_FrameEnter($sSession, Int($aIdentifiers[$i]))
 				$iErr = @error
-;~ 				MsgBox(0, "$bIdentifierAsPath", @ScriptLineNumber & @CRLF & $aIdentifiers[$i]& @CRLF & $iErr)
 			Else
-;~ 				MsgBox(0, "$bIdentifierAsPath", @ScriptLineNumber)
 				$iErr = $_WD_ERROR_InvalidArgue
 			EndIf
 			If $iErr Then ExitLoop

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -543,7 +543,7 @@ EndFunc   ;==>_WD_IsWindowTop
 ;                  Failure - WD Response error message (E.g. "no such frame") and sets @error to $_WD_ERROR_Exception or $_WD_ERROR_InvalidArgue
 ; Author ........: Decibel
 ; Modified ......: mLipok
-; Remarks .......: You can drill-down into nested frames by calling this function repeatedly with the correct parameters.
+; Remarks .......: You can drill-down into nested frames by calling this function repeatedly with the correct parameters or use path like 'null/2/0'
 ; Related .......: _WD_Window, _WD_LastHTTPResult
 ; Link ..........:
 ; Example .......: No
@@ -557,7 +557,7 @@ Func _WD_FrameEnter($sSession, $vIdentifier)
 
 	;*** Encapsulate the value if it's an integer, assuming that it's supposed to be an Index, not ID attrib value.
 	Local Const $aIdentifiers = StringSplit($vIdentifier, '/')
-	Local Const $bIdentifierAsPath = ($aIdentifiers[0] > 1)
+	Local Const $bIdentifierAsPath = ($aIdentifiers[0] > 1) Or Not $bIsIdentifierNull
 	If $bIdentifierAsPath Then
 		For $i = 1 To $aIdentifiers[0]
 			If String($aIdentifiers[$i]) = 'null' Then

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -564,22 +564,15 @@ Func _WD_FrameEnter($sSession, $vIdentifier)
 	Local Const $bIdentifierAsPath = ($aIdentifiers[0] > 1)
 	If $bIdentifierAsPath Then
 		For $i = 1 To $aIdentifiers[0]
-			If String($aIdentifiers[$i]) = 'null' Then
-				$sValue = _WD_FrameEnter($sSession, Null)
-				$iErr = @error
-			ElseIf StringIsDigit($aIdentifiers[$i]) And IsInt(Number($aIdentifiers[$i])) Then
-				$sValue = _WD_FrameEnter($sSession, Int($aIdentifiers[$i]))
-				$iErr = @error
-			Else
-				$iErr = $_WD_ERROR_InvalidArgue
-			EndIf
+			$sValue = _WD_FrameEnter($sSession, $aIdentifiers[$i])
+			$iErr = @error
 			If $iErr Then ExitLoop
 		Next
-		If $i > $aIdentifiers[0] Then $i = $aIdentifiers[0]
+		If $i > $aIdentifiers[0] Then $i = $aIdentifiers[0] ; the case when entire loop was procesed
 		If $iErr Then $sMessage = ' Error on ID#' & $i
 	ElseIf $bIsIdentifierNull Then
 		$sOption = '{"id":null}'
-	ElseIf IsInt($vIdentifier) Then
+	ElseIf StringIsDigit($vIdentifier) And IsInt(Number($vIdentifier)) Then
 		$sOption = '{"id":' & $vIdentifier & '}'
 	Else
 		_WinAPI_GUIDFromString("{" & $vIdentifier & "}")

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -545,7 +545,7 @@ EndFunc   ;==>_WD_IsWindowTop
 ; Return values .: Success - True.
 ;                  Failure - WD Response error message (E.g. "no such frame") and sets @error to $_WD_ERROR_Exception or $_WD_ERROR_InvalidArgue
 ; Author ........: Decibel
-; Modified ......: mLipok
+; Modified ......: Danp2, mLipok, jchd
 ; Remarks .......: You can drill-down into nested frames by calling this function repeatedly with the correct parameters or use path like 'null/2/0'
 ; Related .......: _WD_Window, _WD_LastHTTPResult
 ; Link ..........:

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -560,7 +560,7 @@ Func _WD_FrameEnter($sSession, $vIdentifier)
 	Local $iErr = $_WD_ERROR_Success
 
 	;*** Encapsulate the value if it's an integer, assuming that it's supposed to be an Index, not ID attrib value.
-	Local Const $bIdentifierAsPath = StringRegExp($vIdentifier, '(?i)\ANull\/[\d\/]*\d\Z', $STR_REGEXPMATCH)
+	Local Const $bIdentifierAsPath = StringRegExp($vIdentifier, '(?i)\A(Null\/|)([\d\/]*\d)\Z', $STR_REGEXPMATCH)
 	If $bIdentifierAsPath Then
 		; will be processed below
 	ElseIf $bIsIdentifierNull Then

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -551,20 +551,20 @@ EndFunc   ;==>_WD_IsWindowTop
 Func _WD_FrameEnter($sSession, $vIdentifier)
 	Local Const $sFuncName = "_WD_FrameEnter"
 	Local Const $bIsIdentifierNull = (IsKeyword($vIdentifier) = $KEYWORD_NULL)
-	Local Const $sParameters = 'Parameters:    Identifier=' & ($bIsIdentifierNull ? "Null" : $bIsIdentifierNull)
-	Local $sOption, $sValue, $sResponse, $oJSON, $sMessage = ''
+	Local Const $sParameters = 'Parameters:    Identifier=' & ($bIsIdentifierNull ? "Null" : $vIdentifier)
+	Local $sValue, $sMessage = '', $sOption, $sResponse, $oJSON
 	Local $iErr = $_WD_ERROR_Success
 
 	;*** Encapsulate the value if it's an integer, assuming that it's supposed to be an Index, not ID attrib value.
-	Local $aIdentifiers = StringSplit($vIdentifier, '/')
-	Local $bIdentifierAsPath = ($aIdentifiers[0] > 1)
+	Local Const $aIdentifiers = StringSplit($vIdentifier, '/')
+	Local Const $bIdentifierAsPath = ($aIdentifiers[0] > 1)
 	If $bIdentifierAsPath Then
 		For $i = 1 To $aIdentifiers[0]
 			If $aIdentifiers[$i] = 'null' Then
-				_WD_FrameEnter($sSession, Null)
+				$sValue = _WD_FrameEnter($sSession, Null)
 				$iErr = @error
 			ElseIf StringIsDigit($aIdentifiers[$i]) And IsInt(Number($aIdentifiers[$i])) Then
-				_WD_FrameEnter($sSession, Int($aIdentifiers[$i]))
+				$sValue = _WD_FrameEnter($sSession, Int($aIdentifiers[$i]))
 				$iErr = @error
 			Else
 				$iErr = $_WD_ERROR_InvalidArgue
@@ -589,20 +589,20 @@ Func _WD_FrameEnter($sSession, $vIdentifier)
 	If $iErr = $_WD_ERROR_Success And Not $bIdentifierAsPath Then ; check if $vIdentifier was succesfully validated and not given "as path" with /
 		$sResponse = _WD_Window($sSession, "frame", $sOption)
 		$iErr = @error
-	EndIf
 
-	If $iErr = $_WD_ERROR_Success Then
-		$oJSON = Json_Decode($sResponse)
-		$sValue = Json_Get($oJSON, $_WD_JSON_Value)
+		If $iErr = $_WD_ERROR_Success Then
+			$oJSON = Json_Decode($sResponse)
+			$sValue = Json_Get($oJSON, $_WD_JSON_Value)
 
-		;*** Evaluate the response
-		If $sValue <> Null Then
-			$sValue = Json_Get($oJSON, $_WD_JSON_Error)
-		Else
-			$sValue = True
+			;*** Evaluate the response
+			If $sValue <> Null Then
+				$sValue = Json_Get($oJSON, $_WD_JSON_Error)
+			Else
+				$sValue = True
+			EndIf
+		ElseIf $iErr <> $_WD_ERROR_InvalidArgue Then
+			$iErr = $_WD_ERROR_Exception
 		EndIf
-	ElseIf $iErr <> $_WD_ERROR_InvalidArgue Then
-		$iErr = $_WD_ERROR_Exception
 	EndIf
 
 	Return SetError(__WD_Error($sFuncName, $iErr, $sParameters & $sMessage), 0, $sValue)

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -560,7 +560,7 @@ Func _WD_FrameEnter($sSession, $vIdentifier)
 	Local $iErr = $_WD_ERROR_Success
 
 	;*** Encapsulate the value if it's an integer, assuming that it's supposed to be an Index, not ID attrib value.
-	Local Const $bIdentifierAsPath = StringRegExp($vIdentifier, '(?i)\A(Null\/|)([\d\/]*\d)\Z', $STR_REGEXPMATCH)
+	Local Const $bIdentifierAsPath = ((StringRegExp($vIdentifier, '(?i)\A(Null|\d+)(\/)([\d\/]*\d)\Z', $STR_REGEXPMATCH) = 1) And (StringRegExp($vIdentifier, '\/{2,}', $STR_REGEXPMATCH) = 0)) ; must start with null or digit, must have at least one slash (may have many slashes but should not be followed one per other), must end with digit
 	If $bIdentifierAsPath Then
 		; will be processed below
 	ElseIf $bIsIdentifierNull Then

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -538,12 +538,12 @@ EndFunc   ;==>_WD_IsWindowTop
 ; Description ...: Enter the specified frame.
 ; Syntax ........: _WD_FrameEnter($sSession, $vIdentifier)
 ; Parameters ....: $sSession    - Session ID from _WD_CreateSession
-;                  $vIdentifier - Index (as 0-based Integer) or Element ID (as String) or Null (Keyword) or path in 'null/2/0' format
+;                  $vIdentifier - Identifier of target frame. See remarks for formatting options
 ; Return values .: Success - True.
 ;                  Failure - WD Response error message (E.g. "no such frame") and sets @error to $_WD_ERROR_Exception or $_WD_ERROR_InvalidArgue
 ; Author ........: Decibel
 ; Modified ......: mLipok
-; Remarks .......: You can drill-down into nested frames by calling this function repeatedly with the correct parameters or use path like 'null/2/0'
+; Remarks .......: Identifier can be Null, specific element, or integer. You can drill-down into nested frames by calling this function repeatedly with the correct parameters or use path like 'null/2/0'
 ; Related .......: _WD_Window, _WD_LastHTTPResult
 ; Link ..........:
 ; Example .......: No

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -550,14 +550,15 @@ EndFunc   ;==>_WD_IsWindowTop
 ; ===============================================================================================================================
 Func _WD_FrameEnter($sSession, $vIdentifier)
 	Local Const $sFuncName = "_WD_FrameEnter"
-	Local Const $bIsIdentifierNull = ((IsKeyword($vIdentifier) = $KEYWORD_NULL) Or String($vIdentifier) = 'null')
+	If String($vIdentifier) = 'null' Then $vIdentifier = Null ; String must be used because checking 0 = 'null' is True
+	Local Const $bIsIdentifierNull = (IsKeyword($vIdentifier) = $KEYWORD_NULL)
 	Local Const $sParameters = 'Parameters:    Identifier=' & ($bIsIdentifierNull ? ("Null") : ($vIdentifier))
 	Local $sValue, $sMessage = '', $sOption, $sResponse, $oJSON
 	Local $iErr = $_WD_ERROR_Success
 
 	;*** Encapsulate the value if it's an integer, assuming that it's supposed to be an Index, not ID attrib value.
 	Local Const $aIdentifiers = StringSplit($vIdentifier, '/')
-	Local Const $bIdentifierAsPath = ($aIdentifiers[0] > 1) Or Not $bIsIdentifierNull
+	Local Const $bIdentifierAsPath = ($aIdentifiers[0] > 1)
 	If $bIdentifierAsPath Then
 		For $i = 1 To $aIdentifiers[0]
 			If String($aIdentifiers[$i]) = 'null' Then

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -565,7 +565,7 @@ Func _WD_FrameEnter($sSession, $vIdentifier)
 		; will be processed below
 	ElseIf $bIsIdentifierNull Then
 		$sOption = '{"id":null}'
-	ElseIf StringIsDigit($vIdentifier) And IsInt(Number($vIdentifier)) Then
+	ElseIf IsInt($vIdentifier) Then
 		$sOption = '{"id":' & $vIdentifier & '}'
 	Else
 		_WinAPI_GUIDFromString("{" & $vIdentifier & "}")

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -538,7 +538,7 @@ EndFunc   ;==>_WD_IsWindowTop
 ; Description ...: Enter the specified frame.
 ; Syntax ........: _WD_FrameEnter($sSession, $vIdentifier)
 ; Parameters ....: $sSession    - Session ID from _WD_CreateSession
-;                  $vIdentifier - Index (as 0-based Integer) or Element ID (as String) or Null (Keyword)
+;                  $vIdentifier - Index (as 0-based Integer) or Element ID (as String) or Null (Keyword) or path in 'null/2/0' format
 ; Return values .: Success - True.
 ;                  Failure - WD Response error message (E.g. "no such frame") and sets @error to $_WD_ERROR_Exception or $_WD_ERROR_InvalidArgue
 ; Author ........: Decibel
@@ -550,8 +550,8 @@ EndFunc   ;==>_WD_IsWindowTop
 ; ===============================================================================================================================
 Func _WD_FrameEnter($sSession, $vIdentifier)
 	Local Const $sFuncName = "_WD_FrameEnter"
-	Local Const $bIsIdentifierNull = (IsKeyword($vIdentifier) = $KEYWORD_NULL)
-	Local Const $sParameters = 'Parameters:    Identifier=' & ($bIsIdentifierNull ? "Null" : $vIdentifier)
+	Local Const $bIsIdentifierNull = ((IsKeyword($vIdentifier) = $KEYWORD_NULL) Or String($vIdentifier) = 'null')
+	Local Const $sParameters = 'Parameters:    Identifier=' & ($bIsIdentifierNull ? ("Null") : ($vIdentifier))
 	Local $sValue, $sMessage = '', $sOption, $sResponse, $oJSON
 	Local $iErr = $_WD_ERROR_Success
 
@@ -560,7 +560,7 @@ Func _WD_FrameEnter($sSession, $vIdentifier)
 	Local Const $bIdentifierAsPath = ($aIdentifiers[0] > 1)
 	If $bIdentifierAsPath Then
 		For $i = 1 To $aIdentifiers[0]
-			If $aIdentifiers[$i] = 'null' Then
+			If String($aIdentifiers[$i]) = 'null' Then
 				$sValue = _WD_FrameEnter($sSession, Null)
 				$iErr = @error
 			ElseIf StringIsDigit($aIdentifiers[$i]) And IsInt(Number($aIdentifiers[$i])) Then

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -538,12 +538,15 @@ EndFunc   ;==>_WD_IsWindowTop
 ; Description ...: Enter the specified frame.
 ; Syntax ........: _WD_FrameEnter($sSession, $vIdentifier)
 ; Parameters ....: $sSession    - Session ID from _WD_CreateSession
-;                  $vIdentifier - Identifier of target frame. See remarks for formatting options
+;                  $vIdentifier - Target frame identifier. Can be any of the following:
+;                  |Null    - Return to top-most browsing context
+;                  |String  - Element ID from _WD_FindElement or path like 'null/2/0'
+;                  |Integer - 0-based index of frames
 ; Return values .: Success - True.
 ;                  Failure - WD Response error message (E.g. "no such frame") and sets @error to $_WD_ERROR_Exception or $_WD_ERROR_InvalidArgue
 ; Author ........: Decibel
 ; Modified ......: mLipok
-; Remarks .......: Identifier can be Null, specific element, or integer. You can drill-down into nested frames by calling this function repeatedly with the correct parameters or use path like 'null/2/0'
+; Remarks .......: You can drill-down into nested frames by calling this function repeatedly with the correct parameters or use path like 'null/2/0'
 ; Related .......: _WD_Window, _WD_LastHTTPResult
 ; Link ..........:
 ; Example .......: No


### PR DESCRIPTION
## Pull request

### Proposed changes

This PR add support for:
```autoit
_WD_FrameEnter($sSession, 'null/2/0')
```

### Checklist

Put an `x` in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We are here to help!<br>
This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [ ] Bugfix (change which fixes an issue)
- [x] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [x] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

no way to provide relative/abolute path to desired frame at once

### What is the new behavior?

```autoit
_WD_FrameEnter($sSession, 'null/2/0')
```

### Additional context

https://github.com/Danp2/au3WebDriver/pull/363
and as I said here:
https://github.com/Danp2/au3WebDriver/issues/354#issuecomment-1201402121

> Ultimately I am thinking to be possible of something like this:
> 
> ```autoit
> _WD_FrameEnter($sSession, "Null/2/0/0")
> ```

this PR is finall implementation to this concept

### System under test

not related