### PR TITLE
Add details for using UDF as submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,11 @@ In case you use Firefox, the result should look similar to this:
 
 More useful information following soon.
 
-## Github Integration
+## Configuration
+
+Useful information about possible configurations following soon.<br>
+
+#### Github Integration
 
 To ensure you github project always has the latest version of the UDF.
 
@@ -215,10 +219,6 @@ To ensure you github project always has the latest version of the UDF.
 2. Navigate to your GitHub Autoit repository
 3. Run `git submodule add https://github.com/Danp2/au3WebDriver`
 4. (OPTIONALLY) Run `git mv au3WebDriver Includes\au3WebDriver` to relocate the UDF into an Includes folder
-
-## Configuration
-
-Useful information about possible configurations following soon.<br>
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Useful information about possible configurations following soon.<br>
 
 #### Github Integration
 
-To ensure you github project always has the latest version of the UDF.
+To ensure your GitHub project always has the latest version of the UDF --
 
 1. Open your prefered shell (cmd, powershell, bash, zsh)
 2. Navigate to your GitHub Autoit repository

--- a/README.md
+++ b/README.md
@@ -207,6 +207,15 @@ In case you use Firefox, the result should look similar to this:
 
 More useful information following soon.
 
+## Github Integration
+
+To ensure you github project always has the latest version of the UDF.
+
+1. Open your prefered shell (cmd, powershell, bash, zsh)
+2. Navigate to your GitHub Autoit repository
+3. Run `git submodule add https://github.com/Danp2/au3WebDriver`
+4. (OPTIONALLY) Run `git mv au3WebDriver Includes\au3WebDriver` to relocate the UDF into an Includes folder
+
 ## Configuration
 
 Useful information about possible configurations following soon.<br>


### PR DESCRIPTION
## Pull request

### Proposed changes

Adds details for integrating the UDF into an AutoIt Github Repo as a submodule for easy dependency updates.

### Checklist

Put an `x` in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We are here to help!<br>
This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [x] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [ ] Bugfix (change which fixes an issue)
- [ ] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [x] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

The UDF must be downloaded from releases and uploaded to a project using it. Afterwards, this process must be manually completed for any updates.

### What is the new behavior?

The UDF can now be "embedded" within another repo and updated using `git submodule update`. Allowing for better CI, dependency, and overall AutoIt Github project handling.

### Additional context

As AutoIt does not include any way to manage and update dependencies for projects automatically, git submodules allow this to be done through github itself. Details from github themselves are available here: https://github.blog/2016-02-01-working-with-submodules/

### System under test

N/A