### PR TITLE
DemoCookies() waits on NID cookie existence

### DIFF
--- a/wd_demo.au3
+++ b/wd_demo.au3
@@ -469,7 +469,12 @@ Func DemoCookies()
 	ConsoleWrite("wd_demo.au3: (" & @ScriptLineNumber & ") : Cookies (obtained at start after navigate) : " & $sAllCookies & @CRLF)
 
 	ConsoleWrite("wd_demo.au3: (" & @ScriptLineNumber & ") : WD: Get 'NID' cookie:" & @CRLF)
-	Local $sNID = _WD_Cookies($sSession, 'Get', 'NID')
+	Local $sNID
+	While 1
+		$sNID = _WD_Cookies($sSession, 'Get', 'NID')
+		If Not @error Then ExitLoop
+		Sleep(100) ; this cookie may not exist at start, may appear later when website will be estabilished, so there is need to wait on @error and try again
+	WEnd
 	ConsoleWrite("wd_demo.au3: (" & @ScriptLineNumber & ") : Cookie obtained 'NID' : " & $sNID & @CRLF)
 
 	Local $sName = "TestName"

--- a/wd_demo.au3
+++ b/wd_demo.au3
@@ -469,10 +469,11 @@ Func DemoCookies()
 	ConsoleWrite("wd_demo.au3: (" & @ScriptLineNumber & ") : Cookies (obtained at start after navigate) : " & $sAllCookies & @CRLF)
 
 	ConsoleWrite("wd_demo.au3: (" & @ScriptLineNumber & ") : WD: Get 'NID' cookie:" & @CRLF)
+	Local $hTimer = TimerInit()
 	Local $sNID
 	While 1
 		$sNID = _WD_Cookies($sSession, 'Get', 'NID')
-		If Not @error Then ExitLoop
+		If Not @error Or TimerDiff($hTimer) > 5 * 1000 Then ExitLoop
 		Sleep(100) ; this cookie may not exist at start, may appear later when website will be estabilished, so there is need to wait on @error and try again
 	WEnd
 	ConsoleWrite("wd_demo.au3: (" & @ScriptLineNumber & ") : Cookie obtained 'NID' : " & $sNID & @CRLF)


### PR DESCRIPTION
## Pull request

### Proposed changes

NID cookie may not exist at start, may appear later when website will be estabilished, so there is need to wait on @error and try again

### Checklist

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [x] Bugfix (change which fixes an issue)
- [ ] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

`NID` may not exist after even after `_WD_LoadWait`  

### What is the new behavior?

DemoCookies() waits on NID cookie existence

### Additional context

[wd_demo: review all "Demo****" function](https://github.com/Danp2/au3WebDriver/issues/254)

### System under test
not related
