### PR TITLE
DemoAlerts() - show that prompt was set

### DIFF
--- a/wd_demo.au3
+++ b/wd_demo.au3
@@ -508,7 +508,7 @@ EndFunc   ;==>DemoCookies
 Func DemoAlerts()
 	Local $sStatus, $sText
 
-	; check status before displaying Alert - this should set @error as there is no any Alert displayed yet
+	; check status before displaying Alert
 	$sStatus = _WD_Alert($sSession, 'status')
 	ConsoleWrite("wd_demo.au3: (" & @ScriptLineNumber & ") : " & 'Alert Detected => ' & $sStatus & @CRLF)
 
@@ -526,7 +526,7 @@ Func DemoAlerts()
 	_WD_Alert($sSession, 'Dismiss')
 
 	; show Prompt for testing
-	_WD_ExecuteScript($sSession, "prompt('User Prompt', 'Default value')")
+	_WD_ExecuteScript($sSession, "prompt('User Prompt 1', 'Default value')")
 
 	Sleep(2000)
 
@@ -534,8 +534,16 @@ Func DemoAlerts()
 	_WD_Alert($sSession, 'sendtext', 'new text')
 
 	Sleep(5000)
-	; close Alert
+	; close Alert by acceptance
 	_WD_Alert($sSession, 'Accept')
+
+	Sleep(1000)
+	; show Prompt for testing
+	_WD_ExecuteScript($sSession, "prompt('User Prompt 2', 'Default value')")
+
+	Sleep(5000)
+	; close Alert by rejection
+	_WD_Alert($sSession, 'Dismiss')
 
 EndFunc   ;==>DemoAlerts
 

--- a/wd_demo.au3
+++ b/wd_demo.au3
@@ -508,7 +508,7 @@ EndFunc   ;==>DemoCookies
 Func DemoAlerts()
 	Local $sStatus, $sText
 
-	; check status before displaying Alert
+	; check status before displaying Alert - this should set @error as there is no any Alert displayed yet
 	$sStatus = _WD_Alert($sSession, 'status')
 	ConsoleWrite("wd_demo.au3: (" & @ScriptLineNumber & ") : " & 'Alert Detected => ' & $sStatus & @CRLF)
 

--- a/wd_demo.au3
+++ b/wd_demo.au3
@@ -529,7 +529,7 @@ Func DemoAlerts()
 	_WD_Alert($sSession, 'Dismiss')
 
 	; show Prompt for testing
-	_WD_ExecuteScript($sSession, "window.localStorage.setItem('testing',prompt('User Prompt 1', 'Default value'))")
+	_WD_ExecuteScript($sSession, "prompt('User Prompt 1', 'Default value')")
 	Sleep(2000)
 
 	; Set value of text field
@@ -538,10 +538,6 @@ Func DemoAlerts()
 	Sleep(5000)
 	; close Alert by acceptance
 	_WD_Alert($sSession, 'Accept')
-
-	; check if new value was properly sent to browser (in this case saved in browser Storage)
-	Local $sStorage = _WD_Storage($sSession, 'testing')
-	ConsoleWrite("wd_demo.au3: (" & @ScriptLineNumber & ") : " & '$sStorage => ' & $sStorage & @CRLF)
 
 	Sleep(1000)
 	; show Prompt for testing

--- a/wd_demo.au3
+++ b/wd_demo.au3
@@ -508,6 +508,9 @@ EndFunc   ;==>DemoCookies
 Func DemoAlerts()
 	Local $sStatus, $sText
 
+	_Demo_NavigateCheckBanner($sSession, "https://google.com", '//body/div[1][@aria-hidden="true"]')
+	If @error Then Return SetError(@error, @extended)
+
 	; check status before displaying Alert
 	$sStatus = _WD_Alert($sSession, 'status')
 	ConsoleWrite("wd_demo.au3: (" & @ScriptLineNumber & ") : " & 'Alert Detected => ' & $sStatus & @CRLF)
@@ -522,12 +525,11 @@ Func DemoAlerts()
 	ConsoleWrite("wd_demo.au3: (" & @ScriptLineNumber & ") : " & 'Text Detected => ' & $sText & @CRLF)
 
 	Sleep(5000)
-	; close Alert
+	; close Alert by rejection
 	_WD_Alert($sSession, 'Dismiss')
 
 	; show Prompt for testing
-	_WD_ExecuteScript($sSession, "prompt('User Prompt 1', 'Default value')")
-
+	_WD_ExecuteScript($sSession, "window.localStorage.setItem('testing',prompt('User Prompt 1', 'Default value'))")
 	Sleep(2000)
 
 	; Set value of text field
@@ -536,6 +538,10 @@ Func DemoAlerts()
 	Sleep(5000)
 	; close Alert by acceptance
 	_WD_Alert($sSession, 'Accept')
+
+	; check if new value was stored i Storage
+	Local $sStorage = _WD_Storage($sSession, 'testing')
+	ConsoleWrite("wd_demo.au3: (" & @ScriptLineNumber & ") : " & '$sStorage => ' & $sStorage & @CRLF)
 
 	Sleep(1000)
 	; show Prompt for testing

--- a/wd_demo.au3
+++ b/wd_demo.au3
@@ -508,9 +508,6 @@ EndFunc   ;==>DemoCookies
 Func DemoAlerts()
 	Local $sStatus, $sText
 
-	_Demo_NavigateCheckBanner($sSession, "https://google.com", '//body/div[1][@aria-hidden="true"]')
-	If @error Then Return SetError(@error, @extended)
-
 	; check status before displaying Alert
 	$sStatus = _WD_Alert($sSession, 'status')
 	ConsoleWrite("wd_demo.au3: (" & @ScriptLineNumber & ") : " & 'Alert Detected => ' & $sStatus & @CRLF)
@@ -546,6 +543,27 @@ Func DemoAlerts()
 	Sleep(5000)
 	; close Alert by rejection
 	_WD_Alert($sSession, 'Dismiss')
+
+
+	_WD_Navigate($sSession, 'https://www.quanzhanketang.com/jsref/tryjsref_prompt.html?filename=tryjsref_prompt')
+	_WD_LoadWait($sSession)
+
+	_WD_FrameEnter($sSession, 0)
+
+	Local $sButton = _WD_FindElement($sSession, $_WD_LOCATOR_ByCSSSelector, "button[onclick='myFunction()']")
+
+	_WD_ElementAction($sSession, $sButton, 'CLICK')
+
+	Sleep(2000)
+	; Set value of text field
+	_WD_Alert($sSession, 'sendtext', 'AutoIt user')
+
+	Sleep(2000)
+	; close Alert by acceptance
+	_WD_Alert($sSession, 'Accept')
+
+	; Validate if prompt was properly filled up by _WD_Alert()
+	MsgBox($MB_OK + $MB_TOPMOST + $MB_ICONINFORMATION, "Information", "Check website resposne")
 
 EndFunc   ;==>DemoAlerts
 

--- a/wd_demo.au3
+++ b/wd_demo.au3
@@ -539,7 +539,7 @@ Func DemoAlerts()
 	; close Alert by acceptance
 	_WD_Alert($sSession, 'Accept')
 
-	; check if new value was stored i Storage
+	; check if new value was properly sent to browser (in this case saved in browser Storage)
 	Local $sStorage = _WD_Storage($sSession, 'testing')
 	ConsoleWrite("wd_demo.au3: (" & @ScriptLineNumber & ") : " & '$sStorage => ' & $sStorage & @CRLF)
 


### PR DESCRIPTION
## Pull request

### Proposed changes

this PR is only related to the comment that describe in the specific case what kind of expected result should be to check Alert status

### Checklist

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

- [ ] Bugfix (change which fixes an issue)
- [ ] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (functional, structural)
- [x] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?
`; check status before displaying Alert`

### What is the new behavior?
`; check status before displaying Alert - this should set @error as there is no any Alert displayed yet`

### Additional context

I was checking examples for this ISSUE #254 

### System under test
not related