### PR TITLE
_WD_Alert 'status' return success on False

### DIFF
--- a/wd_core.au3
+++ b/wd_core.au3
@@ -913,6 +913,7 @@ Func _WD_Alert($sSession, $sCommand, $sOption = Default)
 			$iErr = @error
 
 			$sResult = ($iErr = $_WD_ERROR_NoAlert) ? False : True
+			If $iErr = $_WD_ERROR_NoAlert Then $iErr = $_WD_ERROR_Success
 
 		Case Else
 			Return SetError(__WD_Error($sFuncName, $_WD_ERROR_InvalidDataType, "(Accept|Dismiss|GetText|SendText|Status) $sCommand=>" & $sCommand), 0, "")

--- a/wd_core.au3
+++ b/wd_core.au3
@@ -868,12 +868,11 @@ EndFunc   ;==>_WD_ExecuteScript
 ;                  |SENDTEXT - Set the text field of the current user prompt to the given value
 ;                  |STATUS   - Return logical value indicating the presence or absence of an alert
 ;                  $sOption  - [optional] a string value. Default is ""
-; Return values .: Success - Requested data returned by web driver.
+; Return values .: Success - True/False or requested data returned by web driver.
 ;                  Failure - "" (empty string) and sets @error to one of the following values:
-;                  - $_WD_ERROR_NoAlert
 ;                  - $_WD_ERROR_InvalidDataType
 ; Author ........: Danp2
-; Modified ......:
+; Modified ......: mLipok
 ; Remarks .......:
 ; Related .......: _WD_LastHTTPResult
 ; Link ..........: https://www.w3.org/TR/webdriver#user-prompts


### PR DESCRIPTION
## Pull request

### Proposed changes

If function check the status and it is obvious that on false there should be Error , and in this particular case as this is obvious and expected behavior of checking `status` it should not be reported to user as error.

### Checklist

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

- [x] Bugfix (change which fixes an issue)
- [ ] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [x] Documentation content changes
- [x] Other (please describe) - **wondering if it is SCRIPT BREAKING CHANGE ?**

### What is the current behavior?
```
+ wd_demo.au3: Running: DemoAlerts
__WD_Get ==> No alert present [12] : HTTP status = 404
_WD_Alert ==> No alert present [12] : Parameters:   Command=status   Option=Default
wd_demo.au3: (522) : Alert Detected => False
```

### What is the new behavior?

```
+ wd_demo.au3: Running: DemoAlerts
__WD_Get ==> No alert present [12] : HTTP status = 404
wd_demo.au3: (522) : Alert Detected => False
```

### Additional context

was discussed here:
https://github.com/Danp2/au3WebDriver/pull/371#discussion_r940182350

### System under test

not related
