### PR TITLE
_WD_ElementSelectAction 'selectAll' JS validation

### DIFF
--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -1058,20 +1058,20 @@ Func _WD_ElementSelectAction($sSession, $sSelectElement, $sCommand, $aParameters
 							"		return '';" & _
 							"	}; " & _
 							"	let options = SelectElement.options;" & _
-							"	let wasselected = false;" & _
+							"	let waschanged = false;" & _
 							"	for (let i=0, o, isnotdisabled, isnothidden; i < options.length; i++) {" & _
 							"		o = options[i];" & _
 							"		isnotdisabled = (o.disabled==false && 	(!(o.parentNode.nodeName =='OPTGROUP' && o.parentNode.disabled)));" & _
 							"		isnothidden = (o.hidden==false && 		(!(o.parentNode.nodeName =='OPTGROUP' && o.parentNode.hidden)));" & _
 							"		if (isnotdisabled && isnothidden && o.selected==false) {" & _
 							"			o.selected = true;" & _
-							"			wasselected = true;" & _
+							"			waschanged = true;" & _
 							"		};" & _
 							"	};" & _
-							"	if (wasselected==true) {" & _
+							"	if (waschanged==true) {" & _
 							"		SelectElement.dispatchEvent(new Event('change', {bubbles: true}));" & _
 							"	};" & _
-							"	return wasselected;" & _
+							"	return waschanged;" & _
 							"};" & _
 							"var SelectElement = arguments[0]" & _
 							"SelectAll(SelectElement);" & _

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -1052,7 +1052,7 @@ Func _WD_ElementSelectAction($sSession, $sSelectElement, $sCommand, $aParameters
 					EndIf
 
 				Case 'selectAll'
-					$sScript = StringReplace( _
+					Local Static $sScript_SelectAllTemplate = StringReplace( _
 							"function SelectAll(SelectElement) {" & _
 							"	if (SelectElement.multiple == false) {" & _
 							"		return '';" & _
@@ -1076,7 +1076,7 @@ Func _WD_ElementSelectAction($sSession, $sSelectElement, $sCommand, $aParameters
 							"var SelectElement = arguments[0];" & _
 							"SelectAll(SelectElement);" & _
 							"", @TAB, '')
-					$vResult = _WD_ExecuteScript($sSession, $sScript, __WD_JsonElement($sSelectElement), Default, $_WD_JSON_Value)
+					$vResult = _WD_ExecuteScript($sSession, $sScript_SelectAllTemplate, __WD_JsonElement($sSelectElement), Default, $_WD_JSON_Value)
 					$iErr = @error
 					If Not @error And $vResult = '' Then
 						$iErr = $_WD_ERROR_ElementIssue

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -1073,7 +1073,7 @@ Func _WD_ElementSelectAction($sSession, $sSelectElement, $sCommand, $aParameters
 							"	};" & _
 							"	return waschanged;" & _
 							"};" & _
-							"var SelectElement = arguments[0]" & _
+							"var SelectElement = arguments[0];" & _
 							"SelectAll(SelectElement);" & _
 							"", @TAB, '')
 					$vResult = _WD_ExecuteScript($sSession, $sScript, __WD_JsonElement($sSelectElement), Default, $_WD_JSON_Value)

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -1052,14 +1052,35 @@ Func _WD_ElementSelectAction($sSession, $sSelectElement, $sCommand, $aParameters
 					EndIf
 
 				Case 'selectAll'
-					$sScript = _
-							"var options = arguments[0].options;" & _
-							"for ( i=0; i<options.length; i++)" & _
-							"  {if ( (options[i].disabled==false && (!(options.item(i).parentNode.nodeName =='OPTGROUP' && options.item(i).parentNode.disabled))) && (options[i].hidden==false && (!(options.item(i).parentNode.nodeName =='OPTGROUP' && options.item(i).parentNode.hidden))) ) {options[i].selected = true}};" & _
-							"arguments[0].dispatchEvent(new Event('change', {bubbles: true}));" & _
-							"return true;"
+					$sScript = StringReplace( _
+							"function SelectAll(SelectElement) {" & _
+							"	if (SelectElement.multiple == false) {" & _
+							"		return '';" & _
+							"	}; " & _
+							"	let options = SelectElement.options;" & _
+							"	let wasselected = false;" & _
+							"	for (let i=0, o, isnotdisabled, isnothidden; i < options.length; i++) {" & _
+							"		o = options[i];" & _
+							"		isnotdisabled = (o.disabled==false && 	(!(o.parentNode.nodeName =='OPTGROUP' && o.parentNode.disabled)));" & _
+							"		isnothidden = (o.hidden==false && 		(!(o.parentNode.nodeName =='OPTGROUP' && o.parentNode.hidden)));" & _
+							"		if (isnotdisabled && isnothidden && o.selected==false) {" & _
+							"			o.selected = true;" & _
+							"			wasselected = true;" & _
+							"		};" & _
+							"	};" & _
+							"	if (wasselected==true) {" & _
+							"		SelectElement.dispatchEvent(new Event('change', {bubbles: true}));" & _
+							"	};" & _
+							"	return wasselected;" & _
+							"};" & _
+							"var SelectElement = arguments[0]" & _
+							"SelectAll(SelectElement);" & _
+							"", @TAB, '')
 					$vResult = _WD_ExecuteScript($sSession, $sScript, __WD_JsonElement($sSelectElement), Default, $_WD_JSON_Value)
 					$iErr = @error
+					If Not @error And $vResult = '' Then
+						$iErr = $_WD_ERROR_ElementIssue
+					EndIf
 
 				Case 'selectedIndex'
 					$sScript = "return arguments[0].selectedIndex"


### PR DESCRIPTION
## Pull request

### Proposed changes
Functions should have more validation / error checking.
In case when there is no need to select options because they are already selected there should not be done any change to `HTML DOM` so also event should not be fired.

### Checklist

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [ ] Bugfix (change which fixes an issue)
- [x] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?
JS code just going on without any validation

### What is the new behavior?

1.
check if `SelectElement` has `multiple` atribute and set error to `$_WD_ERROR_ElementIssue` if there element is not `multiple` able.

2.
return false when no selection was taken, and not fires change event in such case.

### Additional context
https://github.com/Danp2/au3WebDriver/issues/368#issuecomment-1209081023

### System under test
not related