### PR TITLE
_WD_ElementSelectAction 'options' added group name

### DIFF
--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -1035,13 +1035,25 @@ Func _WD_ElementSelectAction($sSession, $sSelectElement, $sCommand, $aParameters
 						$vResult = _WD_ExecuteScript($sSession, $sScript, __WD_JsonElement($sSelectElement), Default, $_WD_JSON_Value)
 						$iErr = @error
 					EndIf
-				Case 'options' ; 6 columns (value, label, index, selected status, disabled status, and hidden status)
-					$sScript = _
-							"var result ='';" & _
-							"var o = arguments[0].options;" & _
-							"for ( let i = 0; i < o.length; i++ )" & _
-							"  {result += o[i].value + '|' + o[i].label + '|' + o[i].index + '|' + o[i].selected  + '|' + (o[i].disabled || (o[i].parentNode.nodeName =='OPTGROUP' && o[i].parentNode.disabled)) + '|' + (o[i].hidden || (o[i].parentNode.nodeName =='OPTGROUP' && o[i].parentNode.hidden))  + '\n'};" & _
-							"return result;"
+				Case 'options' ; 7 columns (value, label, index, selected status, disabled status, hidden status and group name)
+					$sScript = StringReplace( _
+							"function GetOptions(SelectElement) {" & _
+							"	let result ='';" & _
+							"	let options = SelectElement.options;" & _
+							"	for (let i = 0, o; i < options.length; i++) {" & _
+							"		o = options[i];" & _
+							"		result += o.value + '|' + o.label + '|' + o.index + '|' + o.selected;" & _
+							"		result += '|' + (o.disabled || 	(o.parentNode.nodeName == 'OPTGROUP' && o.parentNode.disabled)	);" & _
+							"		result += '|' + (o.hidden || 	(o.parentNode.nodeName == 'OPTGROUP' && o.parentNode.hidden)	);" & _
+							"		result += '|' + (o.parentNode.nodeName == 'OPTGROUP' ? o.parentNode.label : '');" & _
+							"		result += '\n';" & _
+							"	}" & _
+							"	return result;" & _
+							"}" & _
+							"var SelectElement = arguments[0]" & _
+							"return GetOptions(SelectElement);" & _
+							"", @TAB, '')
+
 					$vResult = _WD_ExecuteScript($sSession, $sScript, __WD_JsonElement($sSelectElement), Default, $_WD_JSON_Value)
 					$iErr = @error
 

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -1036,7 +1036,7 @@ Func _WD_ElementSelectAction($sSession, $sSelectElement, $sCommand, $aParameters
 						$iErr = @error
 					EndIf
 				Case 'options' ; 7 columns (value, label, index, selected status, disabled status, hidden status and group name)
-					$sScript = StringReplace( _
+					Local Static $sScript_OptionsTemplate = StringReplace( _
 							"function GetOptions(SelectElement) {" & _
 							"	let result ='';" & _
 							"	let options = SelectElement.options;" & _
@@ -1054,7 +1054,7 @@ Func _WD_ElementSelectAction($sSession, $sSelectElement, $sCommand, $aParameters
 							"return GetOptions(SelectElement);" & _
 							"", @TAB, '')
 
-					$vResult = _WD_ExecuteScript($sSession, $sScript, __WD_JsonElement($sSelectElement), Default, $_WD_JSON_Value)
+					$vResult = _WD_ExecuteScript($sSession, $sScript_OptionsTemplate, __WD_JsonElement($sSelectElement), Default, $_WD_JSON_Value)
 					$iErr = @error
 
 					If $iErr = $_WD_ERROR_Success Then

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -1058,7 +1058,7 @@ Func _WD_ElementSelectAction($sSession, $sSelectElement, $sCommand, $aParameters
 					$iErr = @error
 
 					If $iErr = $_WD_ERROR_Success Then
-						Local $aAllOptions[0][6]
+						Local $aAllOptions[0][7]
 						_ArrayAdd($aAllOptions, StringStripWS($vResult, $STR_STRIPTRAILING), 0, Default, @LF, $ARRAYFILL_FORCE_SINGLEITEM)
 						$vResult = $aAllOptions
 					EndIf

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -1050,7 +1050,7 @@ Func _WD_ElementSelectAction($sSession, $sSelectElement, $sCommand, $aParameters
 							"	}" & _
 							"	return result;" & _
 							"}" & _
-							"var SelectElement = arguments[0]" & _
+							"var SelectElement = arguments[0];" & _
 							"return GetOptions(SelectElement);" & _
 							"", @TAB, '')
 


### PR DESCRIPTION
## Pull request

### Proposed changes
added new column `group name`  to the result, and refactoring JS for better code maintaince.

### Checklist

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [ ] Bugfix (change which fixes an issue)
- [x] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?
Difficult to move to brwoser console and check.
No information about `group name` 

### What is the new behavior?
JavaScript code was refactored to use functions because this is easier to copy them to browser and test and maintain in the future.
New column `group name` gives better information where `<option>` is placed in `HTML DOM` structure.

### Additional context
none

### System under test
not related
