### PR TITLE
_WD_ElementSelectAction 'selectedOptions' group

### DIFF
--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -1083,7 +1083,7 @@ Func _WD_ElementSelectAction($sSession, $sSelectElement, $sCommand, $aParameters
 					EndIf
 
 				Case 'selectedOptions' ; 4 columns (value, label, index and group name)
-					$sScript = StringReplace( _
+					Local Static $sScript_SelectedOptionsTemplate = StringReplace( _
 							"function GetSelectedOptions(SelectElement) {" & _
 							"	var result ='';" & _
 							"	var options = SelectElement.selectedOptions;" & _
@@ -1096,7 +1096,7 @@ Func _WD_ElementSelectAction($sSession, $sSelectElement, $sCommand, $aParameters
 							"var SelectElement = arguments[0];" & _
 							"return GetSelectedOptions(SelectElement);" & _
 							"", @TAB, '')
-					$vResult = _WD_ExecuteScript($sSession, $sScript, __WD_JsonElement($sSelectElement), Default, $_WD_JSON_Value)
+					$vResult = _WD_ExecuteScript($sSession, $sScript_SelectedOptionsTemplate, __WD_JsonElement($sSelectElement), Default, $_WD_JSON_Value)
 					$iErr = @error
 
 					If $iErr = $_WD_ERROR_Success Then

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -1082,13 +1082,20 @@ Func _WD_ElementSelectAction($sSession, $sSelectElement, $sCommand, $aParameters
 						$vResult = $aSelectedLabels
 					EndIf
 
-				Case 'selectedOptions' ; 4 columns (value, label, index and selected status)
-					$sScript = _
-							"var result ='';" & _
-							"var options = arguments[0].selectedOptions;" & _
-							"for (let i = 0; i < options.length; i++)" & _
-							" {result += options[i].value + '|' + options[i].label + '|' + options[i].index + '|' + options[i].selected + '\n'};" & _
-							"return result;"
+				Case 'selectedOptions' ; 4 columns (value, label, index and group name)
+					$sScript = StringReplace( _
+							"function GetSelectedOptions(SelectElement) {" & _
+							"	var result ='';" & _
+							"	var options = SelectElement.selectedOptions;" & _
+							"	for (let i = 0, o; i < options.length; i++) {" & _
+							"		o = options[i];" & _
+							"		result += o.value + '|' + o.label + '|' + o.index + '|' + (o.parentNode.nodeName == 'OPTGROUP' ? o.parentNode.label : '') + '\n';" & _
+							"	};" & _
+							"	return result;" & _
+							"}" & _
+							"var SelectElement = arguments[0];" & _
+							"return GetSelectedOptions(SelectElement);" & _
+							"", @TAB, '')
 					$vResult = _WD_ExecuteScript($sSession, $sScript, __WD_JsonElement($sSelectElement), Default, $_WD_JSON_Value)
 					$iErr = @error
 


### PR DESCRIPTION
## Pull request

### Proposed changes

removed `options[i].selected` as this was irrational that we return a value that will always be equal `true`
added new column `group name` to the result
refactoring JS for better code maintaince.

### Checklist

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

- [ ] Bugfix (change which fixes an issue)
- [x] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?
 `options[i].selected` always be equal `true` as we use `var options = SelectElement.selectedOptions;`


### What is the new behavior?
refactored JS for better code maintaince.
 `options[i].selected` replaced with `o.parentNode.label`

### Additional context
none

### System under test
not related