### PR TITLE
Improve error detection in winhttp wrapper functions

### DIFF
--- a/wd_core.au3
+++ b/wd_core.au3
@@ -1282,7 +1282,9 @@ EndFunc   ;==>_WD_Shutdown
 ;                  Failure - Response from web driver and sets @error to one of the following values:
 ;                  - $_WD_ERROR_Exception
 ;                  - $_WD_ERROR_InvalidValue
-;                  - $_WD_ERROR_InvalidDataType
+;                  - $_WD_ERROR_SendRecv
+;                  - $_WD_ERROR_SocketError
+;                  - $_WD_ERROR_Timeout
 ; Author ........: Danp2
 ; Modified ......: mLipok
 ; Remarks .......:
@@ -1318,19 +1320,21 @@ Func __WD_Get($sURL)
 				Case $INTERNET_SCHEME_HTTPS
 					$sResponseText = _WinHttpSimpleSSLRequest($hConnect, "GET", $aURL[6] & $aURL[7], Default, Default, $_WD_HTTPContentType)
 				Case Else
-					SetError($_WD_ERROR_InvalidValue)
+					$iResult = $_WD_ERROR_InvalidValue
 			EndSwitch
 
-			$iErr = @error
-			$_WD_HTTPRESULT = @extended
-			$_WD_HTTPRESPONSE = $sResponseText
+			If $iResult = $_WD_ERROR_Success Then
+				$iErr = @error
+				$_WD_HTTPRESULT = @extended
+				$_WD_HTTPRESPONSE = $sResponseText
 
-			If $iErr Then
-				$iResult = $_WD_ERROR_SendRecv
-				$sResponseText = $_WD_WinHTTPTimeoutMsg
-			Else
-				__WD_DetectError($iErr, $sResponseText)
-				$iResult = $iErr
+				If $iErr Then
+					$iResult = $_WD_ERROR_SendRecv
+					$sResponseText = $_WD_WinHTTPTimeoutMsg
+				Else
+					__WD_DetectError($iErr, $sResponseText)
+					$iResult = $iErr
+				EndIf
 			EndIf
 		EndIf
 
@@ -1353,9 +1357,10 @@ EndFunc   ;==>__WD_Get
 ; Return values..: Success - Response from web driver in JSON format
 ;                  Failure - Response from web driver in JSON format and sets @error to one of the following values:
 ;                  - $_WD_ERROR_Exception
-;                  - $_WD_ERROR_Timeout
-;                  - $_WD_ERROR_SocketError
 ;                  - $_WD_ERROR_InvalidValue
+;                  - $_WD_ERROR_SendRecv
+;                  - $_WD_ERROR_SocketError
+;                  - $_WD_ERROR_Timeout
 ; Author ........: Danp2
 ; Modified ......: mLipok
 ; Remarks .......:
@@ -1393,19 +1398,21 @@ Func __WD_Post($sURL, $sData)
 				Case $INTERNET_SCHEME_HTTPS
 					$sResponseText = _WinHttpSimpleSSLRequest($hConnect, "POST", $aURL[6] & $aURL[7], Default, StringToBinary($sData, $_WD_BFORMAT), $_WD_HTTPContentType)
 				Case Else
-					SetError($_WD_ERROR_InvalidValue)
+					$iResult = $_WD_ERROR_InvalidValue
 			EndSwitch
 
-			$iErr = @error
-			$_WD_HTTPRESULT = @extended
-			$_WD_HTTPRESPONSE = $sResponseText
+			If $iResult = $_WD_ERROR_Success Then
+				$iErr = @error
+				$_WD_HTTPRESULT = @extended
+				$_WD_HTTPRESPONSE = $sResponseText
 
-			If $iErr Then
-				$iResult = $_WD_ERROR_SendRecv
-				$sResponseText = $_WD_WinHTTPTimeoutMsg
-			Else
-				__WD_DetectError($iErr, $sResponseText)
-				$iResult = $iErr
+				If $iErr Then
+					$iResult = $_WD_ERROR_SendRecv
+					$sResponseText = $_WD_WinHTTPTimeoutMsg
+				Else
+					__WD_DetectError($iErr, $sResponseText)
+					$iResult = $iErr
+				EndIf
 			EndIf
 		EndIf
 
@@ -1425,9 +1432,10 @@ EndFunc   ;==>__WD_Post
 ; Return values..: Success - Response from web driver.
 ;                  Failure - Response from web driver and sets @error to one of the following values:
 ;                  - $_WD_ERROR_Exception
-;                  - $_WD_ERROR_SendRecv
 ;                  - $_WD_ERROR_InvalidValue
+;                  - $_WD_ERROR_SendRecv
 ;                  - $_WD_ERROR_SocketError
+;                  - $_WD_ERROR_Timeout
 ; Author ........: Danp2
 ; Modified ......: mLipok
 ; Remarks .......:
@@ -1465,19 +1473,21 @@ Func __WD_Delete($sURL)
 				Case $INTERNET_SCHEME_HTTPS
 					$sResponseText = _WinHttpSimpleSSLRequest($hConnect, "DELETE", $aURL[6] & $aURL[7], Default, Default, $_WD_HTTPContentType)
 				Case Else
-					SetError($_WD_ERROR_InvalidValue)
+					$iResult = $_WD_ERROR_InvalidValue
 			EndSwitch
 
-			$iErr = @error
-			$_WD_HTTPRESULT = @extended
-			$_WD_HTTPRESPONSE = $sResponseText
+			If $iResult = $_WD_ERROR_Success Then
+				$iErr = @error
+				$_WD_HTTPRESULT = @extended
+				$_WD_HTTPRESPONSE = $sResponseText
 
-			If $iErr Then
-				$iResult = $_WD_ERROR_SendRecv
-				$sResponseText = $_WD_WinHTTPTimeoutMsg
-			Else
-				__WD_DetectError($iErr, $sResponseText)
-				$iResult = $iErr
+				If $iErr Then
+					$iResult = $_WD_ERROR_SendRecv
+					$sResponseText = $_WD_WinHTTPTimeoutMsg
+				Else
+					__WD_DetectError($iErr, $sResponseText)
+					$iResult = $iErr
+				EndIf
 			EndIf
 		EndIf
 


### PR DESCRIPTION
## Pull request

### Proposed changes

__WD_Get/Put/Delete should detect a prior error condition and not overwrite the value with a different error code

### Checklist

Put an `x` in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We are here to help!<br>
This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [x] Bugfix (change which fixes an issue)
- [ ] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

`__WD_Get("ftp://localhost:4444")` generates the following error, which is technically incorrect because the HTTP request never actually occurred -- 

`__WD_Get ==> Send / Recv error [6] : HTTP status = 0`

### What is the new behavior?

The correct error condition is reported --

`__WD_Get ==> Invalid value [4] : HTTP status = 0`

### Additional context

Add any other context about the problem here.

### System under test

Please complete the following information.

- OS: [e.g. Windows 10]
- OS Arch.: [e.g. X64]
- Browser [e.g. firefox]
- Browser version [e.g. 96.0.3]
