### PR TITLE
$_WD_SupportedBrowsers should be const

### DIFF
--- a/wd_core.au3
+++ b/wd_core.au3
@@ -117,17 +117,6 @@ Global Enum _
 		$_WD_ERROR_Javascript, _ ; Javascript error
 		$_WD_ERROR_COUNTER ; Defines row count for $aWD_ERROR_DESC
 
-Global Enum _ ; Column positions of $_WD_SupportedBrowsers
-		$_WD_BROWSER_Name, _
-		$_WD_BROWSER_ExeName, _
-		$_WD_BROWSER_DriverName, _
-		$_WD_BROWSER_64Bit, _
-		$_WD_BROWSER_OptionsKey, _
-		$_WD_BROWSER_LatestReleaseURL, _
-		$_WD_BROWSER_LatestReleaseRegex, _
-		$_WD_BROWSER_NewDriverURL, _
-		$_WD_BROWSER__COUNTER
-
 Global Const $aWD_ERROR_DESC[$_WD_ERROR_COUNTER] = [ _
 		"Success", _
 		"General Error", _
@@ -166,6 +155,26 @@ Global Const $_WD_ErrorElementIntercept = "element click intercepted"
 Global Const $_WD_ErrorElementNotInteract = "element not interactable"
 
 Global Const $_WD_WinHTTPTimeoutMsg = "WinHTTP request timed out before Webdriver"
+
+Global Enum _ ; Column positions of $_WD_SupportedBrowsers
+		$_WD_BROWSER_Name, _
+		$_WD_BROWSER_ExeName, _
+		$_WD_BROWSER_DriverName, _
+		$_WD_BROWSER_64Bit, _
+		$_WD_BROWSER_OptionsKey, _
+		$_WD_BROWSER_LatestReleaseURL, _
+		$_WD_BROWSER_LatestReleaseRegex, _
+		$_WD_BROWSER_NewDriverURL, _
+		$_WD_BROWSER__COUNTER
+
+Global Const $_WD_SupportedBrowsers[][$_WD_BROWSER__COUNTER] = _
+		[ _
+		["chrome", "chrome.exe", "chromedriver.exe", False, "goog:chromeOptions", "'https://chromedriver.storage.googleapis.com/LATEST_RELEASE_' & StringLeft($sBrowserVersion, StringInStr($sBrowserVersion, '.') - 1)", "", '"https://chromedriver.storage.googleapis.com/" & $sDriverLatest & "/chromedriver_win32.zip"'], _
+		["firefox", "firefox.exe", "geckodriver.exe", True, "moz:firefoxOptions", "https://github.com/mozilla/geckodriver/releases/latest", '<a.*href="\/mozilla\/geckodriver\/releases\/tag\/(?:v)(.*?)"', '"https://github.com/mozilla/geckodriver/releases/download/v" & $sDriverLatest & "/geckodriver-v" & $sDriverLatest & (($bFlag64) ? "-win64.zip" : "-win32.zip")'], _
+		["msedge", "msedge.exe", "msedgedriver.exe", True, "ms:edgeOptions", "'https://msedgedriver.azureedge.net/LATEST_RELEASE_' & StringLeft($sBrowserVersion, StringInStr($sBrowserVersion, '.') - 1) & '_WINDOWS'", "", '"https://msedgedriver.azureedge.net/" & $sDriverLatest & "/edgedriver_" & (($bFlag64) ? "win64.zip" : "win32.zip")'], _
+		["opera", "opera.exe", "operadriver.exe", True, "goog:chromeOptions", "https://github.com/operasoftware/operachromiumdriver/releases/latest", '<a.*href="\/operasoftware\/operachromiumdriver\/releases\/tag\/(?:v\.)(.*?)"', '"https://github.com/operasoftware/operachromiumdriver/releases/download/v." & $sDriverLatest & "/operadriver_" & (($bFlag64) ? "win64.zip" : "win32.zip")'] _
+		]
+
 #EndRegion Global Constants
 
 #Region Global Variables
@@ -193,13 +202,6 @@ Global $_WD_WINHTTP_TIMEOUTS = True
 Global $_WD_HTTPTimeOuts[4] = [0, 60000, 30000, 30000]
 Global $_WD_HTTPContentType = "Content-Type: application/json"
 
-Global $_WD_SupportedBrowsers[][$_WD_BROWSER__COUNTER] = _
-		[ _
-		["chrome", "chrome.exe", "chromedriver.exe", False, "goog:chromeOptions", "'https://chromedriver.storage.googleapis.com/LATEST_RELEASE_' & StringLeft($sBrowserVersion, StringInStr($sBrowserVersion, '.') - 1)", "", '"https://chromedriver.storage.googleapis.com/" & $sDriverLatest & "/chromedriver_win32.zip"'], _
-		["firefox", "firefox.exe", "geckodriver.exe", True, "moz:firefoxOptions", "https://github.com/mozilla/geckodriver/releases/latest", '<a.*href="\/mozilla\/geckodriver\/releases\/tag\/(?:v)(.*?)"', '"https://github.com/mozilla/geckodriver/releases/download/v" & $sDriverLatest & "/geckodriver-v" & $sDriverLatest & (($bFlag64) ? "-win64.zip" : "-win32.zip")'], _
-		["msedge", "msedge.exe", "msedgedriver.exe", True, "ms:edgeOptions", "'https://msedgedriver.azureedge.net/LATEST_RELEASE_' & StringLeft($sBrowserVersion, StringInStr($sBrowserVersion, '.') - 1) & '_WINDOWS'", "", '"https://msedgedriver.azureedge.net/" & $sDriverLatest & "/edgedriver_" & (($bFlag64) ? "win64.zip" : "win32.zip")'], _
-		["opera", "opera.exe", "operadriver.exe", True, "goog:chromeOptions", "https://github.com/operasoftware/operachromiumdriver/releases/latest", '<a.*href="\/operasoftware\/operachromiumdriver\/releases\/tag\/(?:v\.)(.*?)"', '"https://github.com/operasoftware/operachromiumdriver/releases/download/v." & $sDriverLatest & "/operadriver_" & (($bFlag64) ? "win64.zip" : "win32.zip")'] _
-		]
 #EndRegion Global Variables
 
 ; #FUNCTION# ====================================================================================================================


### PR DESCRIPTION
## Pull request

### Proposed changes

Code CleanUp and Good Coding practice

### Checklist

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

- [ ] Bugfix (change which fixes an issue)
- [ ] Feature (change which adds functionality)
- [x] Code style update (formatting, renaming)
- [x] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?
`$_WD_SupportedBrowsers` is declared as `Global`


### What is the new behavior?
`$_WD_SupportedBrowsers` is declared as `Global Const`

`$_WD_BROWSER` was moved as they are related to `$_WD_SupportedBrowsers`

`$_WD_ERROR_COUNTER` is renamed to `$_WD_ERROR__COUNTER` I mean there was added underscore to have better `InteliCode` support. I mean  `$_WD_ERROR_COUNTER`  is not normal variable and should not be used by user thus, typing ``$_WD_ERROR_C` should not popup this variable by `InteliCode` engine, especially when especially for the new upcoming version of SciTE4AutoIt3.

### Additional context

none

### System under test

not related