### PR TITLE
Fix coding where $vResult is compared with an empty string

### DIFF
--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -1096,7 +1096,7 @@ Func _WD_ElementSelectAction($sSession, $sSelectElement, $sCommand, $vParameters
 						$vResult = _WD_ExecuteScript($sSession, $sScript_MultiSelectTemplate, $vParameters, Default, $_WD_JSON_Value)
 						$iErr = @error
 						If Not @error Then
-							If $vResult = '' Then
+							If $vResult == '' Then
 								$iErr = $_WD_ERROR_ElementIssue
 							ElseIf $vResult = False Then
 								$iErr = $_WD_ERROR_NoMatch
@@ -1115,7 +1115,7 @@ Func _WD_ElementSelectAction($sSession, $sSelectElement, $sCommand, $vParameters
 						$vResult = _WD_ExecuteScript($sSession, $sScript_MultiSelectTemplate, $vParameters, Default, $_WD_JSON_Value)
 						$iErr = @error
 						If Not @error Then
-							If $vResult = '' Then
+							If $vResult == '' Then
 								$iErr = $_WD_ERROR_ElementIssue
 							ElseIf $vResult = False Then
 								$iErr = $_WD_ERROR_NoMatch
@@ -1177,7 +1177,7 @@ Func _WD_ElementSelectAction($sSession, $sSelectElement, $sCommand, $vParameters
 							"", @TAB, '')
 					$vResult = _WD_ExecuteScript($sSession, $sScript_SelectAllTemplate, __WD_JsonElement($sSelectElement), Default, $_WD_JSON_Value)
 					$iErr = @error
-					If Not @error And $vResult = '' Then
+					If Not @error And $vResult == '' Then
 						$iErr = $_WD_ERROR_ElementIssue
 					EndIf
 
@@ -1312,7 +1312,7 @@ Func _WD_ElementStyle($sSession, $sElement, $sCSSProperty = Default, $sValue = D
 		$sJavaScript = StringReplace($sJavaScript, @TAB, '')
 		$vResult = _WD_ExecuteScript($sSession, $sJavaScript, __WD_JsonElement($sElement), Default, $_WD_JSON_Value)
 		$iErr = @error
-		If $iErr = $_WD_ERROR_Success And $vResult = '' Then
+		If $iErr = $_WD_ERROR_Success And $vResult == '' Then
 			$iErr = $_WD_ERROR_NoMatch
 		ElseIf $iErr = $_WD_ERROR_Success Then
 			Local $aProperties[0][2]


### PR DESCRIPTION
## Pull request

### Proposed changes


### Checklist

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

- [x] Bugfix (change which fixes an issue)
- [ ] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

if you use
```autoit
_WD_ElementSelectAction($sSession, $sSelectElement, 'SINGLESELECT', 'ParroT')
```
instead
```autoit
_WD_ElementSelectAction($sSession, $sSelectElement, 'SINGLESELECT', 'Parrot')
```

Then you will get error= `$_WD_ERROR_ElementIssue` but the return from JS is not empty string but false.

### What is the new behavior?

correct error number = `$_WD_ERROR_NoMatch`

### Additional context
https://github.com/Danp2/au3WebDriver/pull/377#issuecomment-1217902621

### System under test
not related