### PR TITLE
_WD_LoadWait - better error handling and logging

### DIFF
--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -948,7 +948,7 @@ EndFunc   ;==>_WD_HighlightElements
 ; Return values .: Success - 1.
 ;                  Failure - 0 and sets @error to one of the following values:
 ;                  - $_WD_ERROR_Exception
-;                  - $_WD_ERROR_GeneralError
+;                  - $_WD_ERROR_RetValue
 ;                  - $_WD_ERROR_Timeout
 ; Author ........: Danp2
 ; Modified ......: mLipok
@@ -1009,7 +1009,7 @@ Func _WD_LoadWait($sSession, $iDelay = Default, $iTimeout = Default, $sElement =
 	If $sReadyState Then
 		$iIndex = _ArraySearch($aWD_READYSTATE, $sReadyState, Default, Default, Default, Default, Default, $_WD_READYSTATE_State)
 		If @error Then
-			$iErr = $_WD_ERROR_GeneralError
+			$iErr = $_WD_ERROR_RetValue
 		Else
 			$iExt = $iIndex
 			$sReadyState &= ' (' & $aWD_READYSTATE[$iIndex][$_WD_READYSTATE_Desc] & ')'

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -76,6 +76,22 @@ Global Enum _
 		$_WD_STORAGE_Local = 0, _
 		$_WD_STORAGE_Session = 1
 		
+Global Enum _ ;https://www.w3schools.com/jsref/prop_doc_readystate.asp
+		$_WD_READYSTATE_Uninitialized, _ ; Has not started loading
+		$_WD_READYSTATE_Loading, _  ; Is loading
+		$_WD_READYSTATE_Loaded, _  ; Has been loaded
+		$_WD_READYSTATE_Interactive, _  ; Has loaded enough to interact with
+		$_WD_READYSTATE_Complete, _  ; Fully loaded
+		$_WD_READYSTATE__COUNTER
+
+Global Const $aWD_READYSTATE[$_WD_READYSTATE__COUNTER][2] = [ _
+		["uninitialized", "Has not started loading"], _
+		["loading", "Is loading"], _
+		["loaded", "Has been loaded"], _
+		["interactive", "Has loaded enough to interact with"], _
+		["complete", "Fully loaded"] _
+		]
+
 #EndRegion Global Constants
 
 ; #FUNCTION# ====================================================================================================================
@@ -777,20 +793,20 @@ Func _WD_LoadWait($sSession, $iDelay = Default, $iTimeout = Default, $sElement =
 		Else
 			$sReadyState = _WD_ExecuteScript($sSession, 'return document.readyState', '', Default, $_WD_JSON_Value)
 			$iErr = @error
-			If $iErr Then $iErr = $_WD_ERROR_Exception
-			Switch $sReadyState ; https://www.w3schools.com/jsref/prop_doc_readystate.asp
-				Case 'uninitialized' ; Has not started loading
-					$iExt = 1
-				Case 'loading' ; Is loading
-					$iExt = 2
-				Case 'loaded' ; Has been loaded
-					$iExt = 3
-				Case 'interactive' ; Has loaded enough to interact with
-					$iExt = 4
-				Case 'complete' ; Fully loaded
-					$iExt = 5
-			EndSwitch
-			If $iErr Or $sReadyState = 'complete' Then
+			If $iErr Then
+				$iErr = $_WD_ERROR_Exception
+				$sReadyState = ''
+			Else
+				For $i = 0 To $_WD_READYSTATE__COUNTER - 1
+					If $sReadyState = $aWD_READYSTATE[$i][0] Then ; https://www.w3schools.com/jsref/prop_doc_readystate.asp
+						$iExt = $i
+						$sReadyState &= ' (' & $aWD_READYSTATE[$i][1] & ')'
+						ExitLoop
+					EndIf
+				Next
+			EndIf
+
+			If $iErr Or StringInStr($sReadyState, 'complete') Then
 				ExitLoop
 			EndIf
 		EndIf

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -744,7 +744,7 @@ EndFunc   ;==>_WD_HighlightElements
 ;                  - $_WD_ERROR_Timeout
 ; Author ........: Danp2
 ; Modified ......: mLipok
-; Remarks .......: This function waits only on loading current document context it means that it not waits for loading all frames
+; Remarks .......: Only the current document context is checked (frames must be checked individually)
 ; Related .......: _WD_LastHTTPResult
 ; Link ..........:
 ; Example .......: No

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -83,7 +83,7 @@ Global Enum _
 		$_WD_FRAMELIST_URL = 3, _
 		$_WD_FRAMELIST_BodyID = 4
 
-Global Enum _ ;https://www.w3schools.com/jsref/prop_doc_readystate.asp
+Global Enum _ ; https://www.w3schools.com/jsref/prop_doc_readystate.asp
 		$_WD_READYSTATE_Uninitialized, _ ; Has not started loading
 		$_WD_READYSTATE_Loading, _  ; Is loading
 		$_WD_READYSTATE_Loaded, _  ; Has been loaded
@@ -985,7 +985,7 @@ Func _WD_LoadWait($sSession, $iDelay = Default, $iTimeout = Default, $sElement =
 				$sReadyState = ''
 			Else
 				For $i = 0 To $_WD_READYSTATE__COUNTER - 1
-					If $sReadyState = $aWD_READYSTATE[$i][0] Then ; https://www.w3schools.com/jsref/prop_doc_readystate.asp
+					If $sReadyState = $aWD_READYSTATE[$i][0] Then
 						$iExt = $i
 						$sReadyState &= ' (' & $aWD_READYSTATE[$i][1] & ')'
 						ExitLoop


### PR DESCRIPTION
## Pull request

### Proposed changes

`_WD_LoadWait` should have better error handling and logging

### Checklist

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [ ] Bugfix (change which fixes an issue)
- [x] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [x] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?
On `$_WD_DEBUG_Error` function do not set complete [information about `$iTimeout` reason](https://www.w3schools.com/jsref/prop_doc_readystate.asp).

`_WD_ExecuteScript($sSession, 'return document.readyState', '', Default, $_WD_JSON_Value)` can set error to <> `$_WD_ERROR_Timeout` what was not documented in header.

### What is the new behavior?


added support for `$_WD_ERROR_Exception`

### Additional context

https://www.w3schools.com/jsref/prop_doc_readystate.asp

and `$iExt` shows latest status from: https://www.w3schools.com/jsref/prop_doc_readystate.asp

I was working with https://github.com/Danp2/au3WebDriver/pull/362 and because of this https://github.com/Danp2/au3WebDriver/pull/362#issuecomment-1225545526 I was thinking about small refactoring 
even before we decide about `it would be helpfull to change _WD_LoadWait behavior on the fly without touching capabilities.` : [_WD_LoadWait() enhancements](https://github.com/Danp2/au3WebDriver/issues/385)

### System under test

Please complete the following information.
