### PR TITLE
Add _WD_LocateElement

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ This au3WebDriver UDF (project) allows to interact with any browser that support
 | _WD_ElementOptionSelect | Find and click on an option from a Select element.                              |
 | _WD_ElementSelectAction | Perform action on designated Select element.                                    |
 | _WD_ElementStyle        | Set/Get element style property.                                                 |
+| _WD_FindElementFrames   | Search the current document (including frames) and return locations of matching elements    |
 | _WD_FrameEnter          | Enter the specified frame.                                                      |
 | _WD_FrameLeave          | Leave the current frame, to its parent.                                         |
 | _WD_FrameList           | Retrieves a detailed list of the main document and all associated frames.       |

--- a/README.md
+++ b/README.md
@@ -68,54 +68,54 @@ This au3WebDriver UDF (project) allows to interact with any browser that support
 <summary><i>Helper Functions</i></summary>
 <p>
 
-| Name                    | Description                                                                     |
-|-------------------------|---------------------------------------------------------------------------------|
-| _WD_Attach              | Attach to existing browser tab.                                                 |
-| _WD_CheckContext        | Check if browser context is still valid.                                        |
-| _WD_ConsoleVisible      | Control visibility of the webdriver console app.                                |
-| _WD_DownloadFile        | Download file and save to disk.                                                 |
-| _WD_ElementActionEx     | Perform advanced action on designated element.                                  |
-| _WD_ElementOptionSelect | Find and click on an option from a Select element.                              |
-| _WD_ElementSelectAction | Perform action on designated Select element.                                    |
-| _WD_ElementStyle        | Set/Get element style property.                                                 |
+| Name                    | Description                                                                                 |
+|-------------------------|---------------------------------------------------------------------------------------------|
+| _WD_Attach              | Attach to existing browser tab.                                                             |
+| _WD_CheckContext        | Check if browser context is still valid.                                                    |
+| _WD_ConsoleVisible      | Control visibility of the webdriver console app.                                            |
+| _WD_DownloadFile        | Download file and save to disk.                                                             |
+| _WD_ElementActionEx     | Perform advanced action on designated element.                                              |
+| _WD_ElementOptionSelect | Find and click on an option from a Select element.                                          |
+| _WD_ElementSelectAction | Perform action on designated Select element.                                                |
+| _WD_ElementStyle        | Set/Get element style property.                                                             |
 | _WD_FindElementFrames   | Search the current document (including frames) and return locations of matching elements    |
-| _WD_FrameEnter          | Enter the specified frame.                                                      |
-| _WD_FrameLeave          | Leave the current frame, to its parent.                                         |
-| _WD_FrameList           | Retrieves a detailed list of the main document and all associated frames.       |
-| _WD_GetBrowserPath      | Retrieve path to browser executable from registry.                              |
-| _WD_GetBrowserVersion   | Get version number of specified browser.                                        |
-| _WD_GetDevicePixelRatio | Returns an integer indicating the DevicePixelRatio.                             |
-| _WD_GetElementById      | Locate element by id.                                                           |
-| _WD_GetElementByName    | Locate element by name.                                                         |
-| _WD_GetElementByRegEx   | Find element by matching attributes values using Javascript regular expression. |
-| _WD_GetElementFromPoint | Retrieves reference to element at specified point.                              |
-| _WD_GetFrameCount       | Returns the number of frames/iframes in the current document context.           |
-| _WD_GetMouseElement     | Retrieves reference to element below mouse pointer.                             |
-| _WD_GetShadowRoot       | Retrieves the shadow root of an element.                                        |
-| _WD_GetTable            | Return all elements of a table.                                                 |
-| _WD_GetWebDriverVersion | Get version number of specifed webdriver.                                       |
-| _WD_HighlightElements   | Highlights the specified elements.                                              |
-| _WD_IsFullScreen        | Return a boolean indicating if the session is in full screen mode.              |
-| _WD_IsLatestRelease     | Compares local UDF version to latest release on Github.                         |
-| _WD_IsWindowTop         | Returns a boolean of the session being at the top level, or in a frame(s).      |
-| _WD_JsonActionKey       | Formats keyboard "action" strings for use in _WD_Action                         |
-| _WD_JsonActionPause     | Formats pause "action" strings for use in _WD_Action                            |
-| _WD_JsonActionPointer   | Formats pointer "action" strings for use in _WD_Action                          |
-| _WD_JsonCookie          | Formats "cookie" JSON strings for use in _WD_Cookies.                           |
-| _WD_LastHTTPResponse    | Return the response of the last WinHTTP request.                                |
-| _WD_LastHTTPResult      | Return the result of the last WinHTTP request.                                  |
-| _WD_LinkClickByText     | Simulate a mouse click on a link with text matching the provided string.        |
-| _WD_LoadWait            | Wait for a browser page load to complete before returning.                      |
-| _WD_NewTab              | Create new tab in current browser session.                                      |
-| _WD_PrintToPDF          | Print the current tab in paginated PDF format.                                  |
-| _WD_Screenshot          | Takes a screenshot of the Window or Element.                                    |
-| _WD_SelectFiles         | Select files for uploading to a website.                                        |
-| _WD_SetElementValue     | Set value of designated element.                                                |
-| _WD_SetTimeouts         | User friendly function to set webdriver session timeouts.                       |
-| _WD_Storage             | Provide access to the browser's localStorage and sessionStorage objects.        |
-| _WD_UpdateDriver        | Replace web driver with newer version, if available.                            |
-| _WD_WaitElement         | Wait for an element in the current tab before returning.                        |
-| _WD_jQuerify            | Inject jQuery library into current session.                                     |
+| _WD_FrameEnter          | Enter the specified frame.                                                                  |
+| _WD_FrameLeave          | Leave the current frame, to its parent.                                                     |
+| _WD_FrameList           | Retrieves a detailed list of the main document and all associated frames.                   |
+| _WD_GetBrowserPath      | Retrieve path to browser executable from registry.                                          |
+| _WD_GetBrowserVersion   | Get version number of specified browser.                                                    |
+| _WD_GetDevicePixelRatio | Returns an integer indicating the DevicePixelRatio.                                         |
+| _WD_GetElementById      | Locate element by id.                                                                       |
+| _WD_GetElementByName    | Locate element by name.                                                                     |
+| _WD_GetElementByRegEx   | Find element by matching attributes values using Javascript regular expression.             |
+| _WD_GetElementFromPoint | Retrieves reference to element at specified point.                                          |
+| _WD_GetFrameCount       | Returns the number of frames/iframes in the current document context.                       |
+| _WD_GetMouseElement     | Retrieves reference to element below mouse pointer.                                         |
+| _WD_GetShadowRoot       | Retrieves the shadow root of an element.                                                    |
+| _WD_GetTable            | Return all elements of a table.                                                             |
+| _WD_GetWebDriverVersion | Get version number of specifed webdriver.                                                   |
+| _WD_HighlightElements   | Highlights the specified elements.                                                          |
+| _WD_IsFullScreen        | Return a boolean indicating if the session is in full screen mode.                          |
+| _WD_IsLatestRelease     | Compares local UDF version to latest release on Github.                                     |
+| _WD_IsWindowTop         | Returns a boolean of the session being at the top level, or in a frame(s).                  |
+| _WD_JsonActionKey       | Formats keyboard "action" strings for use in _WD_Action                                     |
+| _WD_JsonActionPause     | Formats pause "action" strings for use in _WD_Action                                        |
+| _WD_JsonActionPointer   | Formats pointer "action" strings for use in _WD_Action                                      |
+| _WD_JsonCookie          | Formats "cookie" JSON strings for use in _WD_Cookies.                                       |
+| _WD_LastHTTPResponse    | Return the response of the last WinHTTP request.                                            |
+| _WD_LastHTTPResult      | Return the result of the last WinHTTP request.                                              |
+| _WD_LinkClickByText     | Simulate a mouse click on a link with text matching the provided string.                    |
+| _WD_LoadWait            | Wait for a browser page load to complete before returning.                                  |
+| _WD_NewTab              | Create new tab in current browser session.                                                  |
+| _WD_PrintToPDF          | Print the current tab in paginated PDF format.                                              |
+| _WD_Screenshot          | Takes a screenshot of the Window or Element.                                                |
+| _WD_SelectFiles         | Select files for uploading to a website.                                                    |
+| _WD_SetElementValue     | Set value of designated element.                                                            |
+| _WD_SetTimeouts         | User friendly function to set webdriver session timeouts.                                   |
+| _WD_Storage             | Provide access to the browser's localStorage and sessionStorage objects.                    |
+| _WD_UpdateDriver        | Replace web driver with newer version, if available.                                        |
+| _WD_WaitElement         | Wait for an element in the current tab before returning.                                    |
+| _WD_jQuerify            | Inject jQuery library into current session.                                                 |
 
 <p>
 </details>

--- a/wd_demo.au3
+++ b/wd_demo.au3
@@ -579,7 +579,7 @@ Func DemoFrames()
 	_Demo_NavigateCheckBanner($sSession, "https://www.w3schools.com/tags/tryit.asp?filename=tryhtml_iframe", '//*[@id="snigel-cmp-framework" and @class="snigel-cmp-framework"]')
 	If @error Then Return SetError(@error, @extended)
 
-	Local $sLocationOfElement1 = _WD_ELementExist($sSession, $_WD_LOCATOR_ByCSSSelector, "div.trytopnav")
+	Local $sLocationOfElement1 = _WD_FindElementFrames($sSession, $_WD_LOCATOR_ByCSSSelector, "div.trytopnav")
 	ConsoleWrite("wd_demo.au3: (" & @ScriptLineNumber & ") : $sLocationOfElement1=" & $sLocationOfElement1 & @CRLF)
 
 	Local $iFrameCount = _WD_GetFrameCount($sSession)
@@ -600,7 +600,7 @@ Func DemoFrames()
 	; after changing context to first frame the current context is not on top level Window
 	ConsoleWrite("wd_demo.au3: (" & @ScriptLineNumber & ") : TopWindow = " & $bIsWindowTop & @CRLF)
 
-	Local $sLocationOfElement2 = _WD_ELementExist($sSession, $_WD_LOCATOR_ByCSSSelector, "div.trytopnav")
+	Local $sLocationOfElement2 = _WD_FindElementFrames($sSession, $_WD_LOCATOR_ByCSSSelector, "div.trytopnav")
 	ConsoleWrite("wd_demo.au3: (" & @ScriptLineNumber & ") : $sLocationOfElement2=" & $sLocationOfElement2 & @CRLF)
 
 	$sElement = _WD_FindElement($sSession, $_WD_LOCATOR_ByXPath, "//iframe")
@@ -707,7 +707,7 @@ Func DemoFrames()
 	ConsoleWrite("! ---> @error=" & @error & "  @extended=" & @extended & " : Example 7" & @CRLF)
 	_ArrayDisplay($aFrameList, 'Example 7 - www.tutorialspoint.com - get frame list as array', 0, 0, Default, 'Absolute Identifiers > _WD_FrameEnter|Relative Identifiers > _WD_FrameEnter|IFRAME attributes|URL|Body ElementID')
 
-	Local $sLocationOfElement3 = _WD_ELementExist($sSession, $_WD_LOCATOR_ByCSSSelector, "li.nav-item[data-bs-original-title='Home Page'] a.nav-link[href='https://www.tutorialspoint.com/index.htm']")
+	Local $sLocationOfElement3 = _WD_FindElementFrames($sSession, $_WD_LOCATOR_ByCSSSelector, "li.nav-item[data-bs-original-title='Home Page'] a.nav-link[href='https://www.tutorialspoint.com/index.htm']")
 	ConsoleWrite("wd_demo.au3: (" & @ScriptLineNumber & ") : $sLocationOfElement3=" & $sLocationOfElement3 & @CRLF)
 
 	MsgBox(0, "", 'After Example 7')

--- a/wd_demo.au3
+++ b/wd_demo.au3
@@ -579,6 +579,11 @@ Func DemoFrames()
 	_Demo_NavigateCheckBanner($sSession, "https://www.w3schools.com/tags/tryit.asp?filename=tryhtml_iframe", '//*[@id="snigel-cmp-framework" and @class="snigel-cmp-framework"]')
 	If @error Then Return SetError(@error, @extended)
 
+	Local $sLocationOfElement1 = _WD_ELementExist($sSession, $_WD_LOCATOR_ByCSSSelector, "div.trytopnav")
+	ConsoleWrite("wd_demo.au3: (" & @ScriptLineNumber & ") : $sLocationOfElement1=" & $sLocationOfElement1 & @CRLF)
+
+	MsgBox(0, "", '$sLocationOfElement1')
+
 	Local $iFrameCount = _WD_GetFrameCount($sSession)
 	If @error Then Return SetError(@error, @extended)
 	ConsoleWrite("wd_demo.au3: (" & @ScriptLineNumber & ") : Frames=" & $iFrameCount & @CRLF)
@@ -596,6 +601,11 @@ Func DemoFrames()
 	$bIsWindowTop = _WD_IsWindowTop($sSession)
 	; after changing context to first frame the current context is not on top level Window
 	ConsoleWrite("wd_demo.au3: (" & @ScriptLineNumber & ") : TopWindow = " & $bIsWindowTop & @CRLF)
+
+	Local $sLocationOfElement2 = _WD_ELementExist($sSession, $_WD_LOCATOR_ByCSSSelector, "div.trytopnav")
+	ConsoleWrite("wd_demo.au3: (" & @ScriptLineNumber & ") : $sLocationOfElement2=" & $sLocationOfElement2 & @CRLF)
+
+	MsgBox(0, "", '$sLocationOfElement2')
 
 	$sElement = _WD_FindElement($sSession, $_WD_LOCATOR_ByXPath, "//iframe")
 	; changing context to first sub frame

--- a/wd_demo.au3
+++ b/wd_demo.au3
@@ -582,8 +582,6 @@ Func DemoFrames()
 	Local $sLocationOfElement1 = _WD_ELementExist($sSession, $_WD_LOCATOR_ByCSSSelector, "div.trytopnav")
 	ConsoleWrite("wd_demo.au3: (" & @ScriptLineNumber & ") : $sLocationOfElement1=" & $sLocationOfElement1 & @CRLF)
 
-	MsgBox(0, "", '$sLocationOfElement1')
-
 	Local $iFrameCount = _WD_GetFrameCount($sSession)
 	If @error Then Return SetError(@error, @extended)
 	ConsoleWrite("wd_demo.au3: (" & @ScriptLineNumber & ") : Frames=" & $iFrameCount & @CRLF)
@@ -604,8 +602,6 @@ Func DemoFrames()
 
 	Local $sLocationOfElement2 = _WD_ELementExist($sSession, $_WD_LOCATOR_ByCSSSelector, "div.trytopnav")
 	ConsoleWrite("wd_demo.au3: (" & @ScriptLineNumber & ") : $sLocationOfElement2=" & $sLocationOfElement2 & @CRLF)
-
-	MsgBox(0, "", '$sLocationOfElement2')
 
 	$sElement = _WD_FindElement($sSession, $_WD_LOCATOR_ByXPath, "//iframe")
 	; changing context to first sub frame
@@ -630,8 +626,9 @@ Func DemoFrames()
 	; after leaving first frame, the current context should back on top level Window
 	ConsoleWrite("wd_demo.au3: (" & @ScriptLineNumber & ") : TopWindow = " & $bIsWindowTop & @CRLF)
 
-	; now lets try to check frame list and using locations as path:
-	; go to website
+	; now lets try to check frame list and using locations as path 'null/0'
+
+	; firstly go to website
 	_WD_Navigate($sSession, 'https://www.w3schools.com/tags/tryit.asp?filename=tryhtml_iframe')
 	_WD_LoadWait($sSession)
 
@@ -644,15 +641,15 @@ Func DemoFrames()
 	; Example 2 - from 'https://www.w3schools.com' get frame list as array
 	Local $aFrameList = _WD_FrameList($sSession, True)
 	ConsoleWrite("! ---> @error=" & @error & "  @extended=" & @extended & " : Example 2" & @CRLF)
-	_ArrayDisplay($aFrameList, 'Example 2 - w3schools.com - get frame list as array, with HTML content of each document', 0, 0, Default, 'Absolute Identifiers > _WD_FrameEnter|Relative Identifiers > _WD_FrameEnter|IFRAME attributes|URL|Body ElementID')
+	_ArrayDisplay($aFrameList, 'Example 2 - w3schools.com - get frame list as array', 0, 0, Default, 'Absolute Identifiers > _WD_FrameEnter|Relative Identifiers > _WD_FrameEnter|IFRAME attributes|URL|Body ElementID')
 
-	; check if document context location is Top Window
+	; check if document context location is Top Window - should be as we are after navigation
 	ConsoleWrite("> " & @ScriptLineNumber & " IsWindowTop = " & _WD_IsWindowTop($sSession) & @CRLF)
 
-	; change document context location
+	; change document context location by path 'null/0'
 	_WD_FrameEnter($sSession, 'null/0')
 
-	; check if document context location is Top Window
+	; check if document context location is Top Window - should not be as we enter to frame 'null/0'
 	ConsoleWrite("> " & @ScriptLineNumber & " IsWindowTop = " & _WD_IsWindowTop($sSession) & @CRLF)
 
 	; Example 3 - from 'https://www.w3schools.com' get frame list as array, while current location is "null/0"
@@ -674,13 +671,13 @@ Func DemoFrames()
 	ConsoleWrite("! ---> @error=" & @error & "  @extended=" & @extended & " : Example 5" & @CRLF)
 	_ArrayDisplay($aFrameList, 'Example 5 - stackoverflow.com - get frame list as array', 0, 0, Default, 'Absolute Identifiers > _WD_FrameEnter|Relative Identifiers > _WD_FrameEnter|IFRAME attributes|URL|Body ElementID')
 
-	; check if document context location is Top Window
+	; check if document context location is Top Window - should be as we are after navigation
 	ConsoleWrite("> " & @ScriptLineNumber & " IsWindowTop = " & _WD_IsWindowTop($sSession) & @CRLF)
 
-	; change document context location
+	; change document context location by path 'null/2'
 	_WD_FrameEnter($sSession, 'null/2')
 
-	; check if document context location is Top Window
+	; check if document context location is Top Window - should not be as we enter to frame 'null/2'
 	ConsoleWrite("> " & @ScriptLineNumber & " IsWindowTop = " & _WD_IsWindowTop($sSession) & @CRLF)
 
 	; Example 6v1 - from 'https://stackoverflow.com' get frame list as array, while is current location is "null/2"
@@ -698,6 +695,22 @@ Func DemoFrames()
 
 	; check if document context location is Top Window
 	ConsoleWrite("> " & @ScriptLineNumber & " IsWindowTop = " & _WD_IsWindowTop($sSession) & @CRLF)
+
+	; now lets try to check locataion of multiple elements on multiple frames
+	; go to website
+	_WD_Navigate($sSession, 'https://www.tutorialspoint.com/html/html_frames.htm#')
+	_WD_LoadWait($sSession)
+
+	MsgBox(0, "", 'Before Example 7')
+
+	$aFrameList = _WD_FrameList($sSession, True)
+	ConsoleWrite("! ---> @error=" & @error & "  @extended=" & @extended & " : Example 7" & @CRLF)
+	_ArrayDisplay($aFrameList, 'Example 7 - www.tutorialspoint.com - get frame list as array', 0, 0, Default, 'Absolute Identifiers > _WD_FrameEnter|Relative Identifiers > _WD_FrameEnter|IFRAME attributes|URL|Body ElementID')
+
+	Local $sLocationOfElement3 = _WD_ELementExist($sSession, $_WD_LOCATOR_ByCSSSelector, "li.nav-item[data-bs-original-title='Home Page'] a.nav-link[href='https://www.tutorialspoint.com/index.htm']")
+	ConsoleWrite("wd_demo.au3: (" & @ScriptLineNumber & ") : $sLocationOfElement3=" & $sLocationOfElement3 & @CRLF)
+
+	MsgBox(0, "", 'After Example 7')
 
 EndFunc   ;==>DemoFrames
 

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -1157,14 +1157,14 @@ EndFunc   ;==>_WD_jQuerify
 
 ; #FUNCTION# ====================================================================================================================
 ; Name ..........: _WD_FindElementFrames
-; Description ...: Check if element exist in all documents (including frames) and return their location
+; Description ...: Search the current document (including frames) and return locations of matching elements
 ; Syntax ........: _WD_FindElementFrames($sSession, $sStrategy, $sSelector[, $bShadowRoot = Default])
 ;                  $iErr = @error[, $iExt = @extended]]]])
 ; Parameters ....: $sSession     - Session ID from _WD_CreateSession
 ;                  $sStrategy    - Locator strategy. See defined constant $_WD_LOCATOR_* for allowed values
 ;                  $sSelector    - $sSelector - Indicates how the WebDriver should traverse through the HTML DOM to locate the desired element(s).
 ;                  $bShadowRoot  - [optional] Starting node is a shadow root? Default is False
-; Return values .: Success - frame location in path
+; Return values .: Success - array of frames location in path format like 'null/2/0'
 ;                  Failure - "" (empty string) and sets @error to one of the following values:
 ;                  - $_WD_ERROR_ElementIssue
 ;                  - $_WD_ERROR_Exception
@@ -1172,7 +1172,8 @@ EndFunc   ;==>_WD_jQuerify
 ;                  - $_WD_ERROR_NoMatch
 ; Author ........: mLipok
 ; Modified ......:
-; Remarks .......: in case when $_WD_ERROR_Exception is set returned location is valid, but was not able back to calling frame
+; Remarks .......: Returned location (path like 'null/2/0') can be used with _WD_FrameEnter before _WD_FindElement or _WD_WaitElement will be used.
+;                  In case when $_WD_ERROR_Exception is set returned location is valid, but was not able back to calling frame.
 ; Related .......: _Wd_FrameList, _WD_FindElement
 ; Link ..........:
 ; Example .......: No
@@ -1229,7 +1230,7 @@ Func _WD_FindElementFrames($sSession, $sStrategy, $sSelector, $bShadowRoot = Def
 	EndIf
 
 	$_WD_DEBUG = $_WD_DEBUG_Saved ; restore DEBUG level
-	If $sLocationOfElement Then $sLocationOfElement = StringTrimRight($sLocationOfElement, 1)
+	If $sLocationOfElement Then $sLocationOfElement = StringTrimRight($sLocationOfElement, 2)
 	$sMessage = $sParameters & $sMessage & '    : LocationOfElement= ' & $sLocationOfElement
 
 	Local $aResults = StringSplit($sLocationOfElement, '|', $STR_NOCOUNT)

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -1156,9 +1156,9 @@ Func _WD_jQuerify($sSession, $sjQueryFile = Default, $iTimeout = Default)
 EndFunc   ;==>_WD_jQuerify
 
 ; #FUNCTION# ====================================================================================================================
-; Name ..........: _WD_ElementExist
+; Name ..........: _WD_FindElementFrames
 ; Description ...: Check if element exist in all documents (including frames) and return their location
-; Syntax ........: _WD_ElementExist($sSession, $sStrategy, $sSelector[, $bShadowRoot = Default])
+; Syntax ........: _WD_FindElementFrames($sSession, $sStrategy, $sSelector[, $bShadowRoot = Default])
 ;                  $iErr = @error[, $iExt = @extended]]]])
 ; Parameters ....: $sSession     - Session ID from _WD_CreateSession
 ;                  $sStrategy    - Locator strategy. See defined constant $_WD_LOCATOR_* for allowed values
@@ -1177,8 +1177,8 @@ EndFunc   ;==>_WD_jQuerify
 ; Link ..........:
 ; Example .......: No
 ; ===============================================================================================================================
-Func _WD_ElementExist($sSession, $sStrategy, $sSelector, $bShadowRoot = Default)
-	Local Const $sFuncName = "_WD_ElementExist"
+Func _WD_FindElementFrames($sSession, $sStrategy, $sSelector, $bShadowRoot = Default)
+	Local Const $sFuncName = "_WD_FindElementFrames"
 	Local Const $sParameters = 'Parameters:   Strategy=' & $sStrategy & '   Selector=' & $sSelector & '   ShadowRoot=' & $bShadowRoot
 	Local $iErr = $_WD_ERROR_Success
 	Local $sStartLocation = '', $sLocationOfElement = '', $sMessage = ''
@@ -1232,7 +1232,7 @@ Func _WD_ElementExist($sSession, $sStrategy, $sSelector, $bShadowRoot = Default)
 
 	$sMessage = $sParameters & $sMessage & '    : LocationOfElement= ' & $sLocationOfElement
 	Return SetError(__WD_Error($sFuncName, $iErr, $sMessage), 0, $sLocationOfElement)
-EndFunc   ;==>_WD_ElementExist
+EndFunc   ;==>_WD_FindElementFrames
 
 ; #FUNCTION# ====================================================================================================================
 ; Name ..........: _WD_ElementOptionSelect

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -1207,8 +1207,8 @@ Func _WD_FindElementFrames($sSession, $sStrategy, $sSelector, $bShadowRoot = Def
 				_WD_FindElement($sSession, $sStrategy, $sSelector, Default, Default, $bShadowRoot)
 				$iErr = @error
 				If $iErr = $_WD_ERROR_Success Then
-					$sLocationOfElement = $aFrameList[$i][$_WD_FRAMELIST_Absolute]
-					ExitLoop
+					$sLocationOfElement &= $aFrameList[$i][$_WD_FRAMELIST_Absolute] & '|'
+					ContinueLoop
 				ElseIf $iErr <> $_WD_ERROR_NoMatch Then
 					$iErr = $_WD_ERROR_ElementIssue
 					$sMessage = ' > Issue with finding element on location: ' & $aFrameList[$i][$_WD_FRAMELIST_Absolute]
@@ -1229,9 +1229,13 @@ Func _WD_FindElementFrames($sSession, $sStrategy, $sSelector, $bShadowRoot = Def
 	EndIf
 
 	$_WD_DEBUG = $_WD_DEBUG_Saved ; restore DEBUG level
-
+	If $sLocationOfElement Then $sLocationOfElement = StringTrimRight($sLocationOfElement, 2)
 	$sMessage = $sParameters & $sMessage & '    : LocationOfElement= ' & $sLocationOfElement
-	Return SetError(__WD_Error($sFuncName, $iErr, $sMessage), 0, $sLocationOfElement)
+
+	Local $aResults = StringSplit($sLocationOfElement, '|', $STR_NOCOUNT)
+	Local $iExt = UBound($aResults, $UBOUND_ROWS)
+	If $iErr Or $iExt = 0 Then $aResults = ''
+	Return SetError(__WD_Error($sFuncName, $iErr, $sMessage, $iExt), $iExt, $aResults)
 EndFunc   ;==>_WD_FindElementFrames
 
 ; #FUNCTION# ====================================================================================================================

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -1229,7 +1229,7 @@ Func _WD_FindElementFrames($sSession, $sStrategy, $sSelector, $bShadowRoot = Def
 	EndIf
 
 	$_WD_DEBUG = $_WD_DEBUG_Saved ; restore DEBUG level
-	If $sLocationOfElement Then $sLocationOfElement = StringTrimRight($sLocationOfElement, 2)
+	If $sLocationOfElement Then $sLocationOfElement = StringTrimRight($sLocationOfElement, 1)
 	$sMessage = $sParameters & $sMessage & '    : LocationOfElement= ' & $sLocationOfElement
 
 	Local $aResults = StringSplit($sLocationOfElement, '|', $STR_NOCOUNT)

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -980,9 +980,9 @@ EndFunc   ;==>_WD_jQuerify
 ; Return values .: Success - frame location in path
 ;                  Failure - "" (empty string) and sets @error to one of the following values:
 ;                  - $_WD_ERROR_ElementIssue
+;                  - $_WD_ERROR_Exception
 ;                  - $_WD_ERROR_GeneralError
 ;                  - $_WD_ERROR_NoMatch
-;                  - $_WD_ERROR_Exception
 ; Author ........: mLipok
 ; Modified ......:
 ; Remarks .......: in case when $_WD_ERROR_Exception is set returned location is valid, but was not able back to calling frame

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -1185,7 +1185,7 @@ Func _WD_ElementExist($sSession, $sStrategy, $sSelector, $bShadowRoot = Default)
 
 	Local $_WD_DEBUG_Saved = $_WD_DEBUG ; save current DEBUG level
 
-	; Prevent logging from _WD_FindElement if not in Full debug mode
+	; Prevent logging from _WD_FindElement and _Wd_FrameList if not in Full debug mode
 	If $_WD_DEBUG <> $_WD_DEBUG_Full Then $_WD_DEBUG = $_WD_DEBUG_None
 
 	Local $aFrameList = _Wd_FrameList($sSession, True)
@@ -1199,15 +1199,21 @@ Func _WD_ElementExist($sSession, $sStrategy, $sSelector, $bShadowRoot = Default)
 		Next
 
 		For $i = 0 To UBound($aFrameList, $UBOUND_ROWS) - 1
-			_WD_FindElement($sSession, $sStrategy, $sSelector, Default, Default, $bShadowRoot)
-			$iErr = @error
-			If $iErr = $_WD_ERROR_Success Then
-				$sLocationOfElement = $aFrameList[$i][$_WD_FRAMELIST_Absolute]
-				ExitLoop
-			ElseIf $iErr <> $_WD_ERROR_NoMatch Then
-				$iErr = $_WD_ERROR_ElementIssue
-				$sMessage = ' > Issue with finding element on location: ' & $aFrameList[$i][$_WD_FRAMELIST_Absolute]
-				ExitLoop
+			_WD_FrameEnter($sSession, $aFrameList[$i][$_WD_FRAMELIST_Absolute])
+			If @error Then
+				$iErr = $_WD_ERROR_GeneralError
+				$sMessage = ' > Issue with entering frame=' & $aFrameList[$i][$_WD_FRAMELIST_Absolute]
+			Else
+				_WD_FindElement($sSession, $sStrategy, $sSelector, Default, Default, $bShadowRoot)
+				$iErr = @error
+				If $iErr = $_WD_ERROR_Success Then
+					$sLocationOfElement = $aFrameList[$i][$_WD_FRAMELIST_Absolute]
+					ExitLoop
+				ElseIf $iErr <> $_WD_ERROR_NoMatch Then
+					$iErr = $_WD_ERROR_ElementIssue
+					$sMessage = ' > Issue with finding element on location: ' & $aFrameList[$i][$_WD_FRAMELIST_Absolute]
+					ExitLoop
+				EndIf
 			EndIf
 		Next
 	EndIf
@@ -1219,7 +1225,7 @@ Func _WD_ElementExist($sSession, $sStrategy, $sSelector, $bShadowRoot = Default)
 	EndIf
 
 	If $sStartLocation = '' Or $iErr Then
-		$sMessage = ' > Was not able to check / back to "calling frame"'
+		$sMessage = ' > Was not able to check / back to "calling frame" : StartLocatkon=' & $sStartLocation
 	EndIf
 
 	$_WD_DEBUG = $_WD_DEBUG_Saved ; restore DEBUG level

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -1171,7 +1171,7 @@ EndFunc   ;==>_WD_jQuerify
 ;                  - $_WD_ERROR_GeneralError
 ;                  - $_WD_ERROR_NoMatch
 ; Author ........: mLipok
-; Modified ......:
+; Modified ......: Danp2
 ; Remarks .......: The returned location can be used with _WD_FrameEnter to switch to the target frame.
 ;                  In case when $_WD_ERROR_Exception is set returned location is valid, but was not able back to calling frame.
 ; Related .......: _Wd_FrameList, _WD_FindElement

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -1172,7 +1172,7 @@ EndFunc   ;==>_WD_jQuerify
 ;                  - $_WD_ERROR_NoMatch
 ; Author ........: mLipok
 ; Modified ......:
-; Remarks .......: Returned location (path like 'null/2/0') can be used with _WD_FrameEnter before _WD_FindElement or _WD_WaitElement will be used.
+; Remarks .......: The returned location can be used with _WD_FrameEnter to switch to the target frame.
 ;                  In case when $_WD_ERROR_Exception is set returned location is valid, but was not able back to calling frame.
 ; Related .......: _Wd_FrameList, _WD_FindElement
 ; Link ..........:

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -774,7 +774,7 @@ EndFunc   ;==>_WD_FrameList
 ; Syntax ........: __WD_FrameList_Internal($sSession, $sLevel, $sFrameAttributes, $_WD_DEBUG_Calling)
 ; Parameters ....: $sSession            - Session ID from _WD_CreateSession
 ;                  $sLevel              - frame location level ... path
-;                  $sFrameAttributes    - all <iframe ....> atributes
+;                  $sFrameAttributes    - all <iframe ....> attributes
 ;                  $_WD_DEBUG_Calling   - log level taken from calling function
 ; Return values .: Success - array or string
 ;                  Failure - "" (empty string) and sets @error to one of the following values:
@@ -828,7 +828,7 @@ Func __WD_FrameList_Internal($sSession, $sLevel, $sFrameAttributes, $_WD_DEBUG_C
 				$sFrameAttributes = _WD_ExecuteScript($sSession, "return document.querySelectorAll('iframe')[" & $iFrame & "].outerHTML;", Default, Default, $_WD_JSON_Value)
 				$iErr = @error
 				If @error Then
-					$sMessage = 'Error occured on "' & $sLevel & '" level when trying to check atributes child frames #' & $iFrame
+					$sMessage = 'Error occured on "' & $sLevel & '" level when trying to check attributes child frames #' & $iFrame
 				Else
 					$sFrameAttributes = StringRegExpReplace($sFrameAttributes, '\R', '')
 					$vResult &= __WD_FrameList_Internal($sSession, $sLevel & '/' & $iFrame, $sFrameAttributes, $_WD_DEBUG_Calling)

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -969,6 +969,45 @@ Func _WD_jQuerify($sSession, $sjQueryFile = Default, $iTimeout = Default)
 EndFunc   ;==>_WD_jQuerify
 
 ; #FUNCTION# ====================================================================================================================
+; Name ..........: _WD_ElementExist
+; Description ...: Check if element exist in all documents (including frames) and return their location
+; Syntax ........: _WD_ElementExist($sSession, $sStrategy, $sSelector[, $bShadowRoot = Default])
+;                  $iErr = @error[, $iExt = @extended]]]])
+; Parameters ....: $sSession            - .....
+;                  $sStrategy           - .....
+;                  $sSelector           - .....
+;                  $bShadowRoot         - [optional] .....
+; Return values .: #TODO
+; Author ........: mLipok
+; Modified ......:
+; Remarks .......:
+; Related .......:
+; Link ..........:
+; Example .......: No
+; ===============================================================================================================================
+Func _WD_ElementExist($sSession, $sStrategy, $sSelector, $bShadowRoot = Default)
+	Local Const $sFuncName = "_WD_ElementExist"
+	Local $iErr = $_WD_ERROR_Success
+	Local Const $sParameters = 'Parameters:   Strategy=' & $sStrategy & '   Selector=' & $sSelector & '   ShadowRoot=' & $bShadowRoot
+
+	Local $_WD_DEBUG_Saved = $_WD_DEBUG ; save current DEBUG level
+
+	; Prevent logging from _WD_FindElement if not in Full debug mode
+	If $_WD_DEBUG <> $_WD_DEBUG_Full Then $_WD_DEBUG = $_WD_DEBUG_None
+
+	#Region - ; TODO use _Wd_FrameList() to check all frames
+	_WD_FindElement($sSession, $sStrategy, $sSelector, Default, Default, $bShadowRoot)
+	$iErr = @error
+	Local $sLocationOfElement = ((@error = 0) ? ('Exist') : (''))
+	#EndRegion - ; TODO _Wd_FrameList() support to check all frames
+
+	$_WD_DEBUG = $_WD_DEBUG_Saved ; restore DEBUG level
+
+	Local $sMessage = $sParameters & '    : LocationOfElement= ' & $sLocationOfElement
+	Return SetError(__WD_Error($sFuncName, $iErr, $sMessage), 0, $sLocationOfElement)
+EndFunc   ;==>_WD_ElementExist
+
+; #FUNCTION# ====================================================================================================================
 ; Name ..........: _WD_ElementOptionSelect
 ; Description ...: Find and click on an option from a Select element.
 ; Syntax ........: _WD_ElementOptionSelect($sSession, $sStrategy, $sSelector[, $sStartElement = Default])


### PR DESCRIPTION
## Pull request

### Proposed changes

There should be easy way to find element location in the frame list returned by `_WD_FrameList`

### Checklist

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [ ] Bugfix (change which fixes an issue)
- [x] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?
No easy way to find element location in the frame list because `_WD_FindElement` finds element only in current location (  main document or desired frame selected by `_WD_FrameEnter`  )

### What is the new behavior?
It shoul be easie with `_WD_ElementExist`

### Additional context
This was initially discussed here: 
https://github.com/Danp2/au3WebDriver/pull/362#issuecomment-1207494392

and here
https://github.com/Danp2/au3WebDriver/pull/362#discussion_r944392108

### System under test
not related