### PR TITLE
_WD_FindElement $sSelector header unification

### DIFF
--- a/wd_core.au3
+++ b/wd_core.au3
@@ -604,7 +604,7 @@ EndFunc   ;==>_WD_Window
 ;                  $bShadowRoot = Default]]])
 ; Parameters ....: $sSession     - Session ID from _WD_CreateSession
 ;                  $sStrategy    - Locator strategy. See defined constant $_WD_LOCATOR_* for allowed values
-;                  $sSelector    - Value to find
+;                  $sSelector    - Indicates how the WebDriver should traverse through the HTML DOM to locate the desired element(s).
 ;                  $sStartNodeID - [optional] Element ID to use as starting node. Default is ""
 ;                  $bMultiple    - [optional] Return multiple matching elements? Default is False
 ;                  $bShadowRoot  - [optional] Starting node is a shadow root? Default is False


### PR DESCRIPTION
## Pull request

### Proposed changes

unification description for `$sSelector` parameter

### Checklist

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

- [ ] Bugfix (change which fixes an issue)
- [ ] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [x] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

`_WD_ElementOptionSelect`, `_WD_GetShadowRoot`, `_WD_SelectFiles` and finally `_WD_WaitElement` all this function have far way better description for `$sSelector` than `_WD_FindElement`

### What is the new behavior?

unified common `$sSelector` parameter description

### Additional context

none

### System under test

not related