### PR TITLE
_WD_LoadWait added DesiredReadyState checking

### DIFF
--- a/wd_demo.au3
+++ b/wd_demo.au3
@@ -1085,7 +1085,7 @@ EndFunc   ;==>DemoStyles
 #Region - UserTesting
 Func UserTesting() ; here you can replace the code to test your stuff before you ask on the forum
 	_WD_Navigate($sSession, 'https://www.google.com')
-	_WD_LoadWait($sSession)
+	_WD_LoadWait($sSession, 10, Default, Default, $_WD_READYSTATE_Interactive)
 
 	ConsoleWrite("- Test 1:" & @CRLF)
 	_WD_FindElement($sSession, $_WD_LOCATOR_ByXPath, '')

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -949,11 +949,12 @@ EndFunc   ;==>_WD_HighlightElements
 ; #FUNCTION# ====================================================================================================================
 ; Name ..........: _WD_LoadWait
 ; Description ...: Wait for a browser page load to complete before returning.
-; Syntax ........: _WD_LoadWait($sSession[, $iDelay = Default[, $iTimeout = Default[, $sElement = Default]]])
+; Syntax ........: _WD_LoadWait($sSession[, $iDelay = Default[, $iTimeout = Default[, $sElement = Default[, $iState = Default]]]])
 ; Parameters ....: $sSession - Session ID from _WD_CreateSession
 ;                  $iDelay   - [optional] Milliseconds to wait before initially checking status
 ;                  $iTimeout - [optional] Period of time (in milliseconds) to wait before exiting function
 ;                  $sElement - [optional] Element ID (from _WD_FindElement or _WD_WaitElement) to confirm DOM invalidation
+;                  $iState   - [optional] Minimal desired ReadyState that is expected. Default is $_WD_READYSTATE_Complete.
 ; Return values .: Success - 1.
 ;                  Failure - 0 and sets @error to one of the following values:
 ;                  - $_WD_ERROR_Exception
@@ -966,9 +967,11 @@ EndFunc   ;==>_WD_HighlightElements
 ; Link ..........:
 ; Example .......: No
 ; ===============================================================================================================================
-Func _WD_LoadWait($sSession, $iDelay = Default, $iTimeout = Default, $sElement = Default)
+Func _WD_LoadWait($sSession, $iDelay = Default, $iTimeout = Default, $sElement = Default, $iState = Default)
 	Local Const $sFuncName = "_WD_LoadWait"
-	Local Const $sParameters = 'Parameters:    Delay=' & $iDelay & '    Timeout=' & $iTimeout & '    Element=' & $sElement
+	If $iState = Default Then $iState = $_WD_READYSTATE_Complete ; Fully loaded
+	Local Const $sDesiredState = _ArrayToString($aWD_READYSTATE, '', $iState, $_WD_READYSTATE__COUNTER - 1, '|', $_WD_READYSTATE_State, $_WD_READYSTATE_State)
+	Local Const $sParameters = 'Parameters:    Delay=' & $iDelay & '    Timeout=' & $iTimeout & '    Element=' & $sElement & '    DesiredState=' & $sDesiredState
 	Local $iErr, $iExt = 0, $sReadyState, $iIndex = -1
 	$_WD_HTTPRESULT = 0
 	$_WD_HTTPRESPONSE = ''
@@ -1000,7 +1003,7 @@ Func _WD_LoadWait($sSession, $iDelay = Default, $iTimeout = Default, $sElement =
 				ExitLoop
 			EndIf
 
-			If $sReadyState = 'complete' Then
+			If StringInStr($sDesiredState, $sReadyState) Then
 				ExitLoop
 			EndIf
 		EndIf

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -970,6 +970,7 @@ EndFunc   ;==>_WD_HighlightElements
 Func _WD_LoadWait($sSession, $iDelay = Default, $iTimeout = Default, $sElement = Default, $iState = Default)
 	Local Const $sFuncName = "_WD_LoadWait"
 	If $iState = Default Then $iState = $_WD_READYSTATE_Complete ; Fully loaded
+	If Not (IsInt($iState) And $iState > 0 And $iState < $_WD_READYSTATE__COUNTER) Then $iState = $_WD_READYSTATE_Complete  ; Fully loaded
 	Local Const $sDesiredState = _ArrayToString($aWD_READYSTATE, '', $iState, $_WD_READYSTATE__COUNTER - 1, '|', $_WD_READYSTATE_State, $_WD_READYSTATE_State)
 	Local Const $sParameters = 'Parameters:    Delay=' & $iDelay & '    Timeout=' & $iTimeout & '    Element=' & $sElement & '    DesiredState=' & $sDesiredState
 	Local $iErr, $iExt = 0, $sReadyState, $iIndex = -1


### PR DESCRIPTION
## Pull request

### Proposed changes

I think we should provide new feature for _WD_LoadWait() as there can be cases that you would like to wait not for complete but for interactive or even loaded will be enough to continue processing like there was no error.

### Checklist

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

- [ ] Bugfix (change which fixes an issue)
- [x] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?
`_WD_LoadWait` always wait for ReadyState = complete


### What is the new behavior?

you can set `$iState` to check for desired state as described here: https://www.w3schools.com/jsref/prop_doc_readystate.asp
```
uninitialized - Has not started loading
loading - Is loading
loaded - Has been loaded
interactive - Has loaded enough to interact with
complete - Fully loaded

```

### Additional context

this was discussed here:   [_WD_LoadWait() enhancements](https://github.com/Danp2/au3WebDriver/issues/385)

### System under test
not related