### PR TITLE
_Demo_NavigateCheckBanner added _WD_LoadWait

### DIFF
--- a/wd_demo.au3
+++ b/wd_demo.au3
@@ -1123,6 +1123,8 @@ Func _Demo_NavigateCheckBanner($sSession, $sURL, $sXpath)
 		ConsoleWrite('wd_demo.au3: (' & @ScriptLineNumber & ') : "' & $sURL & '" page view is hidden - it is possible that the message about COOKIE files was not accepted')
 		Return SetError(@error, @extended)
 	EndIf
+
+	_WD_LoadWait($sSession)
 EndFunc   ;==>_Demo_NavigateCheckBanner
 
 Func SetupGecko($bHeadless)


### PR DESCRIPTION
## Pull request

### Proposed changes

fixing empty `Screen2.png` on FF in `DemoWindows` 

### Checklist

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

- [x] Bugfix (change which fixes an issue)
- [ ] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?
`DemosFunction` from `wd_demo.au3` are not properly waiting for the page to finish loading.
For example using FF i get empty `Screen2.png` with `DemoWindows`


### What is the new behavior?
after adding `_WD_LoadWait` to `_Demo_NavigateCheckBanner` it is fixed

### Additional context
I was testing: [DemoWindows in wd_demo: review all "Demo****" function](https://github.com/Danp2/au3WebDriver/issues/254)
I notice that using FF i get empty `Screen2.png`

### System under test
FF