### PR TITLE
_WD_LinkClickByText: Add starting element

### DIFF
--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -260,10 +260,11 @@ EndFunc   ;==>_WD_Attach
 ; #FUNCTION# ====================================================================================================================
 ; Name ..........: _WD_LinkClickByText
 ; Description ...: Simulate a mouse click on a link with text matching the provided string.
-; Syntax ........: _WD_LinkClickByText($sSession, $sText[, $bPartial = Default])
-; Parameters ....: $sSession - Session ID from _WD_CreateSession
-;                  $sText    - Text to find in link
-;                  $bPartial - [optional] Search by partial text? Default is True
+; Syntax ........: _WD_LinkClickByText($sSession,  $sText[,  $bPartial = Default[,  $sStartElement = Default]])
+; Parameters ....: $sSession      - Session ID from _WD_CreateSession
+;                  $sText         - Text to find in link
+;                  $bPartial      - [optional] Search by partial text? Default is True
+;                  $sStartElement - [optional] Element ID of element to use as starting point
 ; Return values .: Success - None.
 ;                  Failure - "" (empty string) and sets @error to one of the following values:
 ;                  - $_WD_ERROR_Exception
@@ -277,10 +278,11 @@ EndFunc   ;==>_WD_Attach
 ; ===============================================================================================================================
 Func _WD_LinkClickByText($sSession, $sText, $bPartial = Default, $sStartElement = Default)
 	Local Const $sFuncName = "_WD_LinkClickByText"
-	Local Const $sParameters = 'Parameters:   Text=' & $sText & '   Partial=' & $bPartial
+	Local Const $sParameters = 'Parameters:   Text=' & $sText & '   Partial=' & $bPartial & '   StartElement=' & $sStartElement
 	Local $bIsVisible = False, $bIsEnabled = False
 
 	If $bPartial = Default Then $bPartial = True
+	If $sStartElement = Default Then $sStartElement = ""
 
 	Local $aElements = _WD_FindElement($sSession, ($bPartial) ? $_WD_LOCATOR_ByPartialLinkText : $_WD_LOCATOR_ByLinkText, $sText, $sStartElement, True)
 	Local $iErr = @error

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -284,27 +284,15 @@ Func _WD_LinkClickByText($sSession, $sText, $bPartial = Default, $sStartElement 
 	If $bPartial = Default Then $bPartial = True
 	If $sStartElement = Default Then $sStartElement = ""
 
-	Local $aElements = _WD_FindElement($sSession, ($bPartial) ? $_WD_LOCATOR_ByPartialLinkText : $_WD_LOCATOR_ByLinkText, $sText, $sStartElement, True)
+	Local $sElement = _WD_FindElement($sSession, ($bPartial) ? $_WD_LOCATOR_ByPartialLinkText : $_WD_LOCATOR_ByLinkText, $sText, $sStartElement)
 	Local $iErr = @error
 
 	If $iErr = $_WD_ERROR_Success Then
-		For $sElement In $aElements
-			$bIsVisible = _WD_ElementAction($sSession, $sElement, 'displayed')
-			If Not $bIsVisible Then ContinueLoop
+		_WD_ElementAction($sSession, $sElement, 'click')
+		$iErr = @error
 
-			$bIsEnabled = _WD_ElementAction($sSession, $sElement, 'enabled')
-			If $bIsEnabled Then ExitLoop
-		Next
-
-		If $bIsVisible and $bIsEnabled Then
-			_WD_ElementAction($sSession, $sElement, 'click')
-			$iErr = @error
-
-			If $iErr <> $_WD_ERROR_Success Then
-				$iErr = $_WD_ERROR_Exception
-			EndIf
-		Else
-			$iErr = $_WD_ERROR_NoMatch
+		If $iErr <> $_WD_ERROR_Success Then
+			$iErr = $_WD_ERROR_Exception
 		EndIf
 	Else
 		$iErr = $_WD_ERROR_NoMatch

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -279,7 +279,6 @@ EndFunc   ;==>_WD_Attach
 Func _WD_LinkClickByText($sSession, $sText, $bPartial = Default, $sStartElement = Default)
 	Local Const $sFuncName = "_WD_LinkClickByText"
 	Local Const $sParameters = 'Parameters:   Text=' & $sText & '   Partial=' & $bPartial & '   StartElement=' & $sStartElement
-	Local $bIsVisible = False, $bIsEnabled = False
 
 	If $bPartial = Default Then $bPartial = True
 	If $sStartElement = Default Then $sStartElement = ""


### PR DESCRIPTION
## Pull request

### Proposed changes

Enhance the existing _WD_LinkClickByText function by optionally allowing the specification of a starting element.

### Checklist

Put an `x` in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We are here to help!<br>
This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [ ] Bugfix (change which fixes an issue)
- [x] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

Entire webpage is searched

### What is the new behavior?

Uses optional Starting Element parameter of _WD_FindElement to allow the search to be limited to a specific section of the webpage

### Additional context

Add any other context about the problem here.

### System under test

Please complete the following information.

- OS: [e.g. Windows 10]
- OS Arch.: [e.g. X64]
- Browser [e.g. firefox]
- Browser version [e.g. 96.0.3]
