### PR TITLE
_WD_DebugSwitch

### DIFF
--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -450,6 +450,40 @@ Func _WD_WaitElement($sSession, $sStrategy, $sSelector, $iDelay = Default, $iTim
 EndFunc   ;==>_WD_WaitElement
 
 ; #FUNCTION# ====================================================================================================================
+; Name ..........: _WD_DebugSwitch
+; Description ...: Switch to new debug level or switch back to saved debug level
+; Syntax ........: _WD_DebugSwitch([$vMode = Default])
+; Parameters ....: $vMode               - [optional] Set new $_WD_DEBUG level. When not specified (Default) restore saved debug level.
+; Return values .: Success - 1
+;                  Failure - 0
+; Author ........: mLipok
+; Modified ......:
+; Remarks .......: Function saves debug level at first call.
+;                  The first stored value will be never deleted, will be stored on the stack forever.
+; Related .......:
+; Link ..........:
+; Example .......: _WD_DebugSwitch($_WD_DEBUG_Full)
+; ===============================================================================================================================
+Func _WD_DebugSwitch($vMode = Default, $iErr = @error, $iExt = @extended)
+	Local Const $sFuncName = "_WD_DebugSwitch"
+	Local Static $a_WD_DEBUG_SavedStack[1] = [$_WD_DEBUG] ; at first run save currently used debug level to the stack
+	Local $iResult = 0
+
+	If $vMode = Default Then ; restoring saved debug level
+		$_WD_DEBUG = $a_WD_DEBUG_SavedStack[UBound($a_WD_DEBUG_SavedStack) - 1] ; restore last element on the stack
+		; check and do not delete stored debug level if this is the first one on the stack
+		If UBound($a_WD_DEBUG_SavedStack) > 1 Then ReDim $a_WD_DEBUG_SavedStack[UBound($a_WD_DEBUG_SavedStack) - 1]
+		$iResult = 1
+	ElseIf IsInt($vMode) And $vMode < $_WD_DEBUG_None And $vMode > $_WD_DEBUG_Full Then ; setting new debug level
+		ReDim $a_WD_DEBUG_SavedStack[UBound($a_WD_DEBUG_SavedStack) +1] ; resize / add new position to the stack
+		$a_WD_DEBUG_SavedStack[UBound($a_WD_DEBUG_SavedStack) -1]= $vMode ; set new last stack value
+		$_WD_DEBUG = $vMode ; set new debug level
+		$iResult = 1
+	EndIf
+	Return SetError(__WD_Error($sFuncName, $iErr, Default, $iExt), $iExt, $iResult)
+EndFunc   ;==>_WD_DebugSwitch
+
+; #FUNCTION# ====================================================================================================================
 ; Name ..........: _WD_GetMouseElement
 ; Description ...: Retrieves reference to element below mouse pointer.
 ; Syntax ........: _WD_GetMouseElement($sSession)


### PR DESCRIPTION
## Pull request

### Proposed changes

This PR adds function `_WD_DebugSwitch()` which give an easy way to switch and switch back between $_WD_DEBUG levels.

### Checklist

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [ ] Bugfix (change which fixes an issue)
- [x] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

When you want to switch to `$_WD_DEBUG_Full` and then back then you do not must remember which level was set previously.

### What is the new behavior?

this following example shows new behavior:
```autoit
_MAIN()

Func _Main()
	$_WD_DEBUG = $_WD_DEBUG_None ; presetting
	_1()
EndFunc

Func _1()
	_WD_DebugSwitch($_WD_DEBUG_Full) ; first usage - internally store current settings + switch to $_WD_DEBUG_Full
	; do your stuff
	_2()
	_WD_DebugSwitch() ; switch back to prior DEBUG level .... $_WD_DEBUG_None
EndFunc

Func _2()
	_WD_DebugSwitch($_WD_DEBUG_Error) ; switch to $_WD_DEBUG_Error
	; do your stuff
	_WD_DebugSwitch() ; switch back to prior DEBUG level .... $_WD_DEBUG_Full
EndFunc

```

### Additional context

https://www.autoitscript.com/forum/topic/205553-webdriver-udf-help-support-iii/?do=findComment&comment=1504312

### System under test

not related
