### PR TITLE
_WD_CreateSession: Revise default capabilities

### DIFF
--- a/wd_core.au3
+++ b/wd_core.au3
@@ -74,6 +74,7 @@ Global Const $__WDVERSION = "0.11.0"
 Global Const $_WD_ELEMENT_ID = "element-6066-11e4-a52e-4f735466cecf"
 Global Const $_WD_SHADOW_ID = "shadow-6066-11e4-a52e-4f735466cecf"
 Global Const $_WD_EmptyDict = "{}"
+Global Const $_WD_EmptyCaps = '{"capabilities":{}}'
 
 Global Const $_WD_LOCATOR_ByCSSSelector = "css selector"
 Global Const $_WD_LOCATOR_ByXPath = "xpath"
@@ -208,7 +209,7 @@ Global $_WD_HTTPContentType = "Content-Type: application/json"
 ; Name ..........: _WD_CreateSession
 ; Description ...: Request new session from web driver.
 ; Syntax ........: _WD_CreateSession([$sCapabilities = Default])
-; Parameters ....: $sCapabilities - [optional] Requested features in JSON format. Default is "{}"
+; Parameters ....: $sCapabilities - [optional] Requested features in JSON format. Default is '{"capabilities":{}}'
 ; Return values .: Success - Session ID to be used in future requests to web driver session.
 ;                  Failure - "" (empty string) and sets @error to $_WD_ERROR_Exception.
 ; Author ........: Danp2
@@ -222,7 +223,7 @@ Func _WD_CreateSession($sCapabilities = Default)
 	Local Const $sFuncName = "_WD_CreateSession"
 	Local $sSession = "", $sMessage = ''
 
-	If $sCapabilities = Default Then $sCapabilities = $_WD_EmptyDict
+	If $sCapabilities = Default Then $sCapabilities = $_WD_EmptyCaps
 
 	Local $sResponse = __WD_Post($_WD_BASE_URL & ":" & $_WD_PORT & "/session", $sCapabilities)
 	Local $iErr = @error


### PR DESCRIPTION
## Pull request

### Proposed changes

Use revised capabilities when one isn't provided.

### Checklist

Put an `x` in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We are here to help!<br>
This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [x] Bugfix (change which fixes an issue)
- [ ] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

Current default is `{}`, which produces an error with most web drivers.

### What is the new behavior?

New default is `{"capabilities":{}}`

### Additional context

Add any other context about the problem here.

### System under test

Please complete the following information.

- OS: [e.g. Windows 10]
- OS Arch.: [e.g. X64]
- Browser [e.g. firefox]
- Browser version [e.g. 96.0.3]
