### PR TITLE
Add remove DOM element functionality by additional 'REMOVE' command for '_WD_ElementActionEx' function

### DIFF
--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -2416,6 +2416,7 @@ EndFunc   ;==>_WD_SetElementValue
 ;                  |RIGHTCLICK - Do a rightclick on the selected element
 ;                  |SHOW - Change the element's style to 'display: normal' to unhide/show the element
 ;                  |UNCHECK - Unchecks a checkbox input element
+;                  |REMOVE - Removes the element from the DOM
 ;                  $iXOffset    - [optional] X Offset. Default is 0
 ;                  $iYOffset    - [optional] Y Offset. Default is 0
 ;                  $iButton     - [optional] Mouse button. Default is $_WD_BUTTON_Left
@@ -2529,6 +2530,10 @@ Func _WD_ElementActionEx($sSession, $sElement, $sCommand, $iXOffset = Default, $
 		Case 'check', 'uncheck'
 			$iActionType = 2
 			$sJavaScript = "Object.getOwnPropertyDescriptor(arguments[0].__proto__, 'checked').set.call(arguments[0], " & ($sCommand = "check" ? 'true' : 'false') & ");arguments[0].dispatchEvent(new Event('change', { bubbles: true }));"
+
+		Case 'remove'
+			$iActionType = 2
+			$sJavaScript = "arguments[0].remove();"
 
 		Case Else
 			Return SetError(__WD_Error($sFuncName, $_WD_ERROR_InvalidDataType, "(Hover|RightClick|DoubleClick|Click|ClickAndHold|Hide|Show|ChildCount|ModifierClick|Check|Uncheck) $sCommand=>" & $sCommand), 0, "")


### PR DESCRIPTION
Hi 👋 ,

as already described in issue #416, this small adjustment allows the user to choose the `'remove'` command of `_WD_ElementActionEx()` to remove a element from the DOM.

I tested it with Firefox and Chrome which works well. You can test it by this `UserTesting()` code:

``` autoit
Func UserTesting() ; here you can replace the code to test your stuff before you ask on the forum
	_WD_Navigate($sSession, 'https://www.w3schools.com/html/html_tables.asp')

	Local Const $sAcceptDataProtectionButtonSelector = '//div[@id="accept-choices"]'
	_WD_WaitElement($sSession, $_WD_LOCATOR_ByXPath, $sAcceptDataProtectionButtonSelector, 250, 5000, $_WD_OPTION_None)

	Local Const $sAcceptDataProtectionButtonElement = _WD_FindElement($sSession, $_WD_LOCATOR_ByXPath, $sAcceptDataProtectionButtonSelector)
	_WD_ElementAction($sSession, $sAcceptDataProtectionButtonElement, 'click')

	Local Const $sTableRowFourSelector = '//table[@class="ws-table-all"]//tr[4]'
	Local Const $sTableRowFourElement  = _WD_FindElement($sSession, $_WD_LOCATOR_ByXPath, $sTableRowFourSelector)

	MsgBox('', '', 'Before "remove"')
	_WD_ElementActionEx($sSession, $sTableRowFourElement, "remove")
EndFunc   ;==>_USER_WD_Sleep
```

I documented the procedure (see the following screenshots) to show the difference between the already existing `'hide` command and the new `'remove'` command.

With `'hide'`:
![hide1](https://user-images.githubusercontent.com/29656921/220364717-af966f09-3de6-4f0f-8901-95c8afada6cd.png)
![hide2](https://user-images.githubusercontent.com/29656921/220364786-26d2421d-d35c-4d0a-978c-f970e44b31ad.png)

With `'remove'`:
![remove1](https://user-images.githubusercontent.com/29656921/220364872-2c6ca5a5-e5c5-4cea-9e83-4046aacdb5d5.png)
![remove2](https://user-images.githubusercontent.com/29656921/220364913-f218e539-be9c-4d5d-ab40-4835c0d09cef.png)

I guess that's it 😀 . 

Best regards
Sven

