### PR TITLE
_WD_FrameLeave error reporting fix

### DIFF
--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -727,7 +727,7 @@ Func _WD_FrameLeave($sSession)
 		$iErr = $_WD_ERROR_Exception
 	EndIf
 
-	Return SetError(__WD_Error($sFuncName, $_WD_ERROR_Success), 0, $sValue)
+	Return SetError(__WD_Error($sFuncName, $iErr), 0, $sValue)
 EndFunc   ;==>_WD_FrameLeave
 
 ; #FUNCTION# ====================================================================================================================


### PR DESCRIPTION
## Pull request

### Proposed changes

fixing error reporting

### Checklist

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

- [x] Bugfix (change which fixes an issue)
- [ ] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?
return point always return success
```autoit
Return SetError(__WD_Error($sFuncName, $_WD_ERROR_Success), 0, $sValue)
```

### What is the new behavior?
returns proper $iErr

```autoit
Return SetError(__WD_Error($sFuncName, $iErr), 0, $sValue)
```

### Additional context

none

### System under test
not related