### PR TITLE
_WD_ElementActionEx - inner comments suplemented

### DIFF
--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -2595,19 +2595,23 @@ Func _WD_ElementActionEx($sSession, $sElement, $sCommand, $iXOffset = Default, $
 
 	If $bScrollView Then
 		_WD_ExecuteScript($sSession, "arguments[0].scrollIntoView(false);", __WD_JsonElement($sElement))
-		Sleep(500)
+		__WD_Sleep(500)
 	EndIf
 
-	Switch $iActionType
-		Case 1
-			$sAction = StringFormat($sActionTemplate, $sPreAction, $iXOffset, $iYOffset, $sElement, $sElement, $sPostHoverAction, $sPostAction)
-			$sResult = _WD_Action($sSession, 'actions', $sAction)
-			$iErr = @error
+	If @error Then
+		$iErr = @error
+	Else
+		Switch $iActionType
+			Case 1
+				$sAction = StringFormat($sActionTemplate, $sPreAction, $iXOffset, $iYOffset, $sElement, $sElement, $sPostHoverAction, $sPostAction)
+				$sResult = _WD_Action($sSession, 'actions', $sAction)
+				$iErr = @error
 
-		Case 2
-			$sResult = _WD_ExecuteScript($sSession, $sJavaScript, __WD_JsonElement($sElement), Default, $_WD_JSON_Value)
-			$iErr = @error
-	EndSwitch
+			Case 2
+				$sResult = _WD_ExecuteScript($sSession, $sJavaScript, __WD_JsonElement($sElement), Default, $_WD_JSON_Value)
+				$iErr = @error
+		EndSwitch
+	EndIf
 
 	Return SetError(__WD_Error($sFuncName, $iErr, $sParameters), 0, $sResult)
 EndFunc   ;==>_WD_ElementActionEx

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -2595,23 +2595,19 @@ Func _WD_ElementActionEx($sSession, $sElement, $sCommand, $iXOffset = Default, $
 
 	If $bScrollView Then
 		_WD_ExecuteScript($sSession, "arguments[0].scrollIntoView(false);", __WD_JsonElement($sElement))
-		__WD_Sleep(500)
+		Sleep(500) ; short Sleep() outside of the loop so no need to use __WD_Sleep()
 	EndIf
 
-	If @error Then
-		$iErr = @error
-	Else
-		Switch $iActionType
-			Case 1
-				$sAction = StringFormat($sActionTemplate, $sPreAction, $iXOffset, $iYOffset, $sElement, $sElement, $sPostHoverAction, $sPostAction)
-				$sResult = _WD_Action($sSession, 'actions', $sAction)
-				$iErr = @error
+	Switch $iActionType
+		Case 1
+			$sAction = StringFormat($sActionTemplate, $sPreAction, $iXOffset, $iYOffset, $sElement, $sElement, $sPostHoverAction, $sPostAction)
+			$sResult = _WD_Action($sSession, 'actions', $sAction)
+			$iErr = @error
 
-			Case 2
-				$sResult = _WD_ExecuteScript($sSession, $sJavaScript, __WD_JsonElement($sElement), Default, $_WD_JSON_Value)
-				$iErr = @error
-		EndSwitch
-	EndIf
+		Case 2
+			$sResult = _WD_ExecuteScript($sSession, $sJavaScript, __WD_JsonElement($sElement), Default, $_WD_JSON_Value)
+			$iErr = @error
+	EndSwitch
 
 	Return SetError(__WD_Error($sFuncName, $iErr, $sParameters), 0, $sResult)
 EndFunc   ;==>_WD_ElementActionEx


### PR DESCRIPTION
## Pull request

### Proposed changes

Sleep() should not be used directly to have the $_WD_ERROR_UserAbort feature available

### Checklist

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

- [ ] Bugfix (change which fixes an issue)
- [ ] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [x] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?
after scrolling script is stopped by Sleep() function whith out possibility to interact with.

### What is the new behavior?
__WD_Sleep() gives more interaction to the script

### Additional context
I would like to do this more flexible the script should check if it is visible or not and then scroll or not, after which should wait to be visible, and not only simply Sleep()

### System under test
not related