### PR TITLE
Let _WD_Window accept unformatted handles

### DIFF
--- a/wd_core.au3
+++ b/wd_core.au3
@@ -561,7 +561,7 @@ Func _WD_Window($sSession, $sCommand, $sOption = Default)
 			$iErr = @error
 
 		Case 'switch'
-			If $sOption <> "" And StringLeft($sOption, 1) <> "{" Then $sOption = '{"handle":"' & $sOption & '"}'
+			$sOption = __WD_JsonHandle($sOption)
 			$sResponse = __WD_Post($sURLSession & "window", $sOption)
 			$iErr = @error
 
@@ -569,7 +569,7 @@ Func _WD_Window($sSession, $sCommand, $sOption = Default)
 			If $sOption = '' Then
 				$sResponse = __WD_Get($sURLSession & $sCommand)
 			Else
-				If StringLeft($sOption, 1) <> "{" Then $sOption = '{"handle":"' & $sOption & '"}'
+				$sOption = __WD_JsonHandle($sOption)
 				$sResponse = __WD_Post($sURLSession & $sCommand, $sOption)
 			EndIf
 
@@ -1756,7 +1756,7 @@ Func __WD_DetectError(ByRef $iErr, $vResult)
 
 			Case $_WD_ErrorWindowNotFound
 				$iErr = $_WD_ERROR_ContextInvalid
-				
+
 			Case Else
 				$iErr = $_WD_ERROR_Exception
 
@@ -1864,3 +1864,20 @@ Func __WD_Sleep($iPause)
 	$_WD_Sleep($iPause)
 	If @error Then Return SetError($_WD_ERROR_UserAbort)
 EndFunc   ;==>__WD_Sleep
+
+; #INTERNAL_USE_ONLY# ===========================================================================================================
+; Name ..........: __WD_JsonHandle
+; Description ...: Converts a handle into JSON string as needed
+; Syntax ........: __WD_JsonHandle($sHandle)
+; Parameters ....: $sHandle - Element ID from _WD_Window
+; Return values .: Formatted JSON string
+; Author ........: Seadoggie
+; Modified ......:
+; Remarks .......:
+; Related .......: __WD_JsonElement
+; Link ..........:
+; Example .......: No
+; ===============================================================================================================================
+Func __WD_JsonHandle($sHandle)
+	Return (StringLeft($sHandle, 1) <> '{') ? ('{"handle":"' & $sHandle & '"}') : ($sHandle)
+EndFunc   ;==>__WD_JsonHandle

--- a/wd_core.au3
+++ b/wd_core.au3
@@ -561,6 +561,7 @@ Func _WD_Window($sSession, $sCommand, $sOption = Default)
 			$iErr = @error
 
 		Case 'switch'
+			If $sOption <> "" And StringLeft($sOption, 1) <> "{" Then $sOption = '{"handle":"' & $sOption & '"}'
 			$sResponse = __WD_Post($sURLSession & "window", $sOption)
 			$iErr = @error
 
@@ -568,6 +569,7 @@ Func _WD_Window($sSession, $sCommand, $sOption = Default)
 			If $sOption = '' Then
 				$sResponse = __WD_Get($sURLSession & $sCommand)
 			Else
+				If StringLeft($sOption, 1) <> "{" Then $sOption = '{"handle":"' & $sOption & '"}'
 				$sResponse = __WD_Post($sURLSession & $sCommand, $sOption)
 			EndIf
 


### PR DESCRIPTION
## Pull request

### Proposed changes

_WD_Window($sSession, "handles") returns an array of handles. This lets _WD_Window accept its own return values directly instead of having to remember to type '{"handle":"' & $aHandles[1] & '"}' each time

### Checklist

Put an `x` in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We are here to help!<br>
This is simply a reminder of what we are going to look for before merging your code.

- [X] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [X] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [X] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [ ] Bugfix (change which fixes an issue)
- [X] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

_WD_Window needs formatted handles

### What is the new behavior?

_WD_Window attempts to format unformatted handles

### Additional context

N/A

### System under test

Please complete the following information.

- OS: Windows 10
- OS Arch.: X64
- Browser: Edge
- Browser version: 110.0.1587.50
