### PR TITLE
_WD_Shutdown: Add delay before closing webdriver

### DIFF
--- a/wd_core.au3
+++ b/wd_core.au3
@@ -1292,8 +1292,9 @@ EndFunc   ;==>_WD_Startup
 ; #FUNCTION# ====================================================================================================================
 ; Name ..........: _WD_Shutdown
 ; Description ...: Kill the web driver console app.
-; Syntax ........: _WD_Shutdown([$vDriver = Default])
+; Syntax ........: _WD_Shutdown([$vDriver = Default[,  $iPa$iDelayuse = Default]])
 ; Parameters ....: $vDriver - [optional] The name or PID of Web driver console to shutdown
+;                  $iDelay  - [optional] Time (in milliseconds) to pause before beginning console shutdown
 ; Return values .: None
 ; Author ........: Danp2
 ; Modified ......:
@@ -1302,7 +1303,13 @@ EndFunc   ;==>_WD_Startup
 ; Link ..........:
 ; Example .......: No
 ; ===============================================================================================================================
-Func _WD_Shutdown($vDriver = Default)
+Func _WD_Shutdown($vDriver = Default, $iDelay = Default)
+	If $iDelay = Default Then $iDelay = 2000
+	If $iDelay Then __WD_Sleep($iDelay)
+
+	; Not checking @error here because we aren't concerned
+	; with user abort during execution of shutdown
+
 	__WD_CloseDriver($vDriver)
 EndFunc   ;==>_WD_Shutdown
 

--- a/wd_core.au3
+++ b/wd_core.au3
@@ -1292,7 +1292,7 @@ EndFunc   ;==>_WD_Startup
 ; #FUNCTION# ====================================================================================================================
 ; Name ..........: _WD_Shutdown
 ; Description ...: Kill the web driver console app.
-; Syntax ........: _WD_Shutdown([$vDriver = Default[,  $iPa$iDelayuse = Default]])
+; Syntax ........: _WD_Shutdown([$vDriver = Default[,  $iDelay = Default]])
 ; Parameters ....: $vDriver - [optional] The name or PID of Web driver console to shutdown
 ;                  $iDelay  - [optional] Time (in milliseconds) to pause before beginning console shutdown
 ; Return values .: None
@@ -1305,7 +1305,7 @@ EndFunc   ;==>_WD_Startup
 ; ===============================================================================================================================
 Func _WD_Shutdown($vDriver = Default, $iDelay = Default)
 	If $iDelay = Default Then $iDelay = 2000
-	If $iDelay Then __WD_Sleep($iDelay)
+	If IsInt($iDelay) And $iDelay > 0 Then __WD_Sleep($iDelay)
 
 	; Not checking @error here because we aren't concerned
 	; with user abort during execution of shutdown


### PR DESCRIPTION
## Pull request

### Proposed changes

Pause before shutting down webdriver consoles to allow them to finish any background processing

### Checklist

Put an `x` in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We are here to help!<br>
This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [x] Bugfix (change which fixes an issue)
- [ ] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

See #440 

### What is the new behavior?

_WD_Shutdown will default to pausing for 2 seconds before killing the target webdriver. The length can be overridden using the new optional `$iDelay` parameter.

### Additional context

Code is commented regarding the intentional lack of checking for errors following the call to __WD_Sleep

### System under test

Please complete the following information.

- OS: [e.g. Windows 10]
- OS Arch.: [e.g. X64]
- Browser [e.g. firefox]
- Browser version [e.g. 96.0.3]
