### PR TITLE
Add _WD_GetContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,10 @@ Go to [legend](#legend---types-of-changes) for further information about the typ
 
 ### Added
 
-- _WD_WaitScript (@ye7iaserag)
 - _WD_FrameListFindElement (@mlipok)
+- _WD_GetContext
 - _WD_Option: Support for `DetailErrors` option
+- _WD_WaitScript (@ye7iaserag)
 
 ### Changed
 - _WD_FrameList (@mlipok)

--- a/README.md
+++ b/README.md
@@ -84,8 +84,10 @@ This au3WebDriver UDF (project) allows to interact with any browser that support
 | _WD_FrameEnter          | Enter the specified frame.                                                      |
 | _WD_FrameLeave          | Leave the current frame, to its parent.                                         |
 | _WD_FrameList           | Retrieves a detailed list of the main document and all associated frames.       |
+| _WD_FrameListFindElement| Search the current document and return locations of matching elements.          |
 | _WD_GetBrowserPath      | Retrieve path to browser executable from registry.                              |
 | _WD_GetBrowserVersion   | Get version number of specified browser.                                        |
+| _WD_GetContext          | Retrieve the element ID of the current browsing context.                        |
 | _WD_GetDevicePixelRatio | Returns an integer indicating the DevicePixelRatio.                             |
 | _WD_GetElementById      | Locate element by id.                                                           |
 | _WD_GetElementByName    | Locate element by name.                                                         |
@@ -118,6 +120,7 @@ This au3WebDriver UDF (project) allows to interact with any browser that support
 | _WD_Storage             | Provide access to the browser's localStorage and sessionStorage objects.        |
 | _WD_UpdateDriver        | Replace web driver with newer version, if available.                            |
 | _WD_WaitElement         | Wait for an element in the current tab before returning.                        |
+| _WD_WaitScript          | Wait for a JavaScript snippet to return true.                                   |
 | _WD_jQuerify            | Inject jQuery library into current session.                                     |
 
 <p>

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -2918,6 +2918,29 @@ Func _WD_CheckContext($sSession, $bReconnect = Default, $vTarget = Default)
 EndFunc   ;==>_WD_CheckContext
 
 ; #FUNCTION# ====================================================================================================================
+; Name ..........: _WD_GetContext
+; Description ...: Retrieve the element ID of the current browsing context
+; Syntax ........: _WD_GetContext($sSession)
+; Parameters ....: $sSession - Session ID from _WD_CreateSession
+; Return values .: Success - Element ID of current frame / document
+;                  Failure - "" and sets @error to value returned from _WD_ExecuteScript()
+; Author ........: Danp2
+; Modified ......:
+; Remarks .......:
+; Related .......: 
+; Link ..........:
+; Example .......: No
+; ===============================================================================================================================
+Func _WD_GetContext($sSession)
+	Local Const $sFuncName = "_WD_GetContext"
+	Local $sElement = _WD_ExecuteScript($sSession, "return window.document.body;", Default, Default, $_WD_JSON_Element)
+	Local $iErr = @error
+
+	If $iErr Then $sElement = ""
+	Return SetError(__WD_Error($sFuncName, $iErr), 0, $sElement)
+EndFunc
+
+; #FUNCTION# ====================================================================================================================
 ; Name ..........: _WD_GetElementByRegEx
 ; Description ...: Find element by matching attributes values using Javascript regular expression
 ; Syntax ........: _WD_GetElementByRegEx($sSession, $sMode, $sRegExPattern[, $sRegExFlags = ""[, $bAll = False]])


### PR DESCRIPTION
## Pull request

### Proposed changes

Add function to enable retrieval of current browsing context<br>
Please ensure you have read and noticed the checklist below.

### Checklist

Put an `x` in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We are here to help!<br>
This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [ ] Bugfix (change which fixes an issue)
- [x] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

No simple way to determine current browsing context

### What is the new behavior?

`_WD_GetContext` can be used to obtain the current browsing context.

### Additional context

Eliminates need to call `_WD_FrameList`, which requires many calls to webdriver

### System under test

N/A