### PR TITLE
SetupEdge - user-data-dir - admin support

### DIFF
--- a/wd_demo.au3
+++ b/wd_demo.au3
@@ -1233,6 +1233,7 @@ Func SetupEdge($bHeadless)
 	_WD_CapabilitiesAdd('alwaysMatch', 'msedge')
 	_WD_CapabilitiesAdd('excludeSwitches', 'enable-automation')
 	If $bHeadless Then _WD_CapabilitiesAdd('args', '--headless')
+	_WD_CapabilitiesAdd('args', 'user-data-dir', @LocalAppDataDir & '\Microsoft\Edge\User Data\WD_Testing_Profile')
 	_WD_CapabilitiesDump(@ScriptLineNumber) ; dump current Capabilities setting to console - only for testing in this demo
 	Local $sCapabilities = _WD_CapabilitiesGet()
 	Return $sCapabilities


### PR DESCRIPTION
## Pull request

### Proposed changes

Add support for runing MS EDGE with elevated to admin 
```autoit
#RequireAdmin
```

### Checklist

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

- [X] Bugfix (change which fixes an issue)
- [ ] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

using SetupEdge with elevation to Admin will hit error

### What is the new behavior?

works properly

### Additional context

https://www.autoitscript.com/forum/topic/210071-webdriver-and-admin-rights

https://www.autoitscript.com/forum/topic/210071-webdriver-and-admin-rights/?do=findComment&comment=1516684

### System under test

MS EDGE