### PR TITLE
wd_demo.au3 - better error handling

### DIFF
--- a/wd_demo.au3
+++ b/wd_demo.au3
@@ -285,6 +285,7 @@ Func _RunDemo_ErrorHander($bForceDispose, $iError, $iExtended, $iWebDriver_PID, 
 		Case Else
 			ConsoleWrite("! Error = " & $iError & " occurred on: " & $sDemoName & @CRLF)
 			ConsoleWrite("! _WD_LastHTTPResult = " & _WD_LastHTTPResult() & @CRLF)
+			ConsoleWrite("! _WD_LastHTTPResponse = " & _WD_LastHTTPResponse() & @CRLF)
 			ConsoleWrite("! _WD_GetSession = " & _WD_GetSession($sSession) & @CRLF)
 			MsgBox($MB_ICONERROR + $MB_TOPMOST, $sDemoName & ' error!', 'Check logs')
 	EndSwitch
@@ -1169,16 +1170,21 @@ EndFunc   ;==>_USER_WD_Sleep
 
 Func _Demo_NavigateCheckBanner($sSession, $sURL, $sXpath)
 	_WD_Navigate($sSession, $sURL)
+	If @error Then Return SetError(@error, @extended, 0)
+
 	_WD_LoadWait($sSession)
+	If @error Then Return SetError(@error, @extended, 0)
 
 	; Check if designated element is visible, as it can hide all sub elements in case when COOKIE aproval message is visible
 	_WD_WaitElement($sSession, $_WD_LOCATOR_ByXPath, $sXpath, 0, 1000 * 60, $_WD_OPTION_NoMatch)
 	If @error Then
+		Local $iErr = @error, $iExt = @extended
 		ConsoleWrite('wd_demo.au3: (' & @ScriptLineNumber & ') : "' & $sURL & '" page view is hidden - it is possible that the message about COOKIE files was not accepted')
-		Return SetError(@error, @extended)
+		Return SetError($iErr, $iExt)
 	EndIf
 
 	_WD_LoadWait($sSession)
+	Return SetError(@error, @extended, 0)
 EndFunc   ;==>_Demo_NavigateCheckBanner
 
 Func SetupGecko($bHeadless)


### PR DESCRIPTION
## Pull request

### Proposed changes

Better error handling in WD_Demo.

### Checklist

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

- [ ] Bugfix (change which fixes an issue)
- [ ] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

Not stopts processing even after error

### What is the new behavior?

should stop in case of error

### Additional context

I was working on:
https://github.com/Danp2/au3WebDriver/pull/454

and notice the issue that after unsuccessfull navigating it still doing some other struff

### System under test

not related