### PR TITLE
Expand _WD_FrameList with Delay and Timeout parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Go to [legend](#legend---types-of-changes) for further information about the typ
 	- Refactored for better performance
 	- Improved frame support
 	- Improved logging
+	- Optional parameters to control initial delay and timeout
 - Enable optional detailed error reporting
 	- _WD_Attach
 	- _WD_CreateSession

--- a/wd_demo.au3
+++ b/wd_demo.au3
@@ -710,13 +710,13 @@ Func DemoFrames()
 
 	MsgBox($MB_TOPMOST, "", 'Before checking location of multiple elements on multiple frames' & @CRLF & 'Try the same example with and without waiting about 30 seconds in order to see that many frames should be fully loaded, and to check the differences')
 
-	$aFrameList = _WD_FrameList($sSession, True)
+	$aFrameList = _WD_FrameList($sSession, True, 5000, Default)
 	ConsoleWrite("! ---> @error=" & @error & "  @extended=" & @extended & " : Example : Testing element location in frame set - after pre-checking list of frames" & @CRLF)
-	_ArrayDisplay($aFrameList, 'Before _WD_FrameListFindElement - www.tutorialspoint.com - get frame list as array', 0, 0, Default, $sArrayHeader)
+	_ArrayDisplay($aFrameList, @ScriptLineNumber & ' Before _WD_FrameListFindElement - www.tutorialspoint.com - get frame list as array', 0, 0, Default, $sArrayHeader)
 
-	Local $aLocationOfElement = _WD_FrameListFindElement($sSession, $_WD_LOCATOR_ByCSSSelector, "li.nav-item[data-bs-original-title='Home Page'] a.nav-link[href='https://www.tutorialspoint.com/index.htm']")
+	Local $aLocationOfElement = _WD_FrameListFindElement($sSession, $_WD_LOCATOR_ByCSSSelector, "li.nav-item[data-bs-original-title='Home Page'] a.nav-link[href='https://www.tutorialspoint.com/index.htm']", 5000, Default)
 	ConsoleWrite("wd_demo.au3: (" & @ScriptLineNumber & ") : $aLocationOfElement (" & UBound($aLocationOfElement) & ")=" & @CRLF & _ArrayToString($aLocationOfElement) & @CRLF)
-	_ArrayDisplay($aLocationOfElement, '$aLocationOfElement', 0, 0, Default, $sArrayHeader)
+	_ArrayDisplay($aLocationOfElement, @ScriptLineNumber & ' $aLocationOfElement', 0, 0, Default, $sArrayHeader)
 
 	#EndRegion - Testing element location in frame set and iframe collecion
 EndFunc   ;==>DemoFrames

--- a/wd_demo.au3
+++ b/wd_demo.au3
@@ -714,7 +714,7 @@ Func DemoFrames()
 	ConsoleWrite("! ---> @error=" & @error & "  @extended=" & @extended & " : Example : Testing element location in frame set - after pre-checking list of frames" & @CRLF)
 	_ArrayDisplay($aFrameList, @ScriptLineNumber & ' Before _WD_FrameListFindElement - www.tutorialspoint.com - get frame list as array', 0, 0, Default, $sArrayHeader)
 
-	Local $aLocationOfElement = _WD_FrameListFindElement($sSession, $_WD_LOCATOR_ByCSSSelector, "li.nav-item[data-bs-original-title='Home Page'] a.nav-link[href='https://www.tutorialspoint.com/index.htm']", 5000, Default)
+	Local $aLocationOfElement = _WD_FrameListFindElement($sSession, $_WD_LOCATOR_ByCSSSelector, "li.nav-item[data-bs-original-title='Home Page'] a.nav-link[href='https://www.tutorialspoint.com/index.htm']")
 	ConsoleWrite("wd_demo.au3: (" & @ScriptLineNumber & ") : $aLocationOfElement (" & UBound($aLocationOfElement) & ")=" & @CRLF & _ArrayToString($aLocationOfElement) & @CRLF)
 	_ArrayDisplay($aLocationOfElement, @ScriptLineNumber & ' $aLocationOfElement', 0, 0, Default, $sArrayHeader)
 

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -830,6 +830,7 @@ EndFunc   ;==>_WD_FrameLeave
 ;                  - $_WD_ERROR_Exception
 ;                  - $_WD_ERROR_NotFound
 ;                  - $_WD_ERROR_RetValue
+;                  - $_WD_ERROR_UserAbort
 ; Author ........: mLipok
 ; Modified ......: Danp2
 ; Remarks .......: The returned list of frames can depend on many factors, including geolocation, as well as problems with the local Internet
@@ -843,9 +844,10 @@ Func _WD_FrameList($sSession, $bReturnAsArray = True, $iDelay = 1000, $iTimeout 
 	Local $a_Result[0][$_WD_FRAMELIST__COUNTER], $sStartLocation = '', $sMessage = ''
 	Local $vResult = '', $iErr = $_WD_ERROR_Success, $iFrameCount = 0
 
-	_WD_LoadWait($sSession, $iDelay, $iTimeout, Default, $_WD_READYSTATE_Complete) ; first _WD_LoadWait with declared $iDelay
-
 	Local Const $sElement_CallingFrameBody = _WD_ExecuteScript($sSession, "return window.document.body;", Default, Default, $_WD_JSON_Element)
+	If Not @error Then
+		__WD_Sleep($iDelay)
+	EndIf
 	If Not @error Then
 		$vResult = __WD_FrameList_Internal($sSession, 'null', '', False, $iTimeout)
 	EndIf
@@ -881,7 +883,7 @@ Func _WD_FrameList($sSession, $bReturnAsArray = True, $iDelay = 1000, $iTimeout 
 			EndIf
 		EndIf
 
-	ElseIf $iErr <> $_WD_ERROR_Timeout And Not $_WD_DetailedErrors Then
+	ElseIf $iErr <> $_WD_ERROR_Timeout And $iErr <> $_WD_ERROR_UserAbort And Not $_WD_DetailedErrors Then
 		$iErr = $_WD_ERROR_GeneralError
 	EndIf
 

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -847,7 +847,7 @@ Func _WD_FrameList($sSession, $bReturnAsArray = True, $iDelay = 1000, $iTimeout 
 
 	Local Const $sElement_CallingFrameBody = _WD_ExecuteScript($sSession, "return window.document.body;", Default, Default, $_WD_JSON_Element)
 	If Not @error Then
-		$vResult = __WD_FrameList_Internal($sSession, 'null', '', False, $iDelay, $iTimeout)
+		$vResult = __WD_FrameList_Internal($sSession, 'null', '', False, $iTimeout)
 	EndIf
 	$iErr = @error
 	#Region - post processing
@@ -923,7 +923,7 @@ EndFunc   ;==>_WD_FrameList
 ; ===============================================================================================================================
 Func __WD_FrameList_Internal($sSession, $sLevel, $sFrameAttributes, $bIsHidden, $iTimeout = Default)
 	Local Const $sFuncName = "__WD_FrameList_Internal"
-	Local Const $sParameters = 'Parameters:    Level=' & $sLevel & '    IsHidden=' & $bIsHidden & '    iDelay=' & $iDelay & '    iTimeout=' & $iTimeout ; intentionally $sFrameAttributes is not listed here to not put too many data into the log
+	Local Const $sParameters = 'Parameters:    Level=' & $sLevel & '    IsHidden=' & $bIsHidden & '    Timeout=' & $iTimeout ; intentionally $sFrameAttributes is not listed here to not put too many data into the log
 	Local $iErr = $_WD_ERROR_Success, $sMessage = '', $vResult = ''
 	Local $s_URL = '', $sCurrentBody_ElementID = ''
 
@@ -994,7 +994,7 @@ Func __WD_FrameList_Internal($sSession, $sLevel, $sFrameAttributes, $bIsHidden, 
 							$sMessage = 'Error occurred on "' & $sLevel & '" level when trying to check visibility of subframe "' & $sLevel & '/' & $iFrame & '"'
 							ContinueLoop
 						Else
-							$vResult &= __WD_FrameList_Internal($sSession, $sLevel & '/' & $iFrame, $sFrameAttributes, $bIsHidden, $iDelay, $iTimeout)
+							$vResult &= __WD_FrameList_Internal($sSession, $sLevel & '/' & $iFrame, $sFrameAttributes, $bIsHidden, $iTimeout)
 							$iErr = @error
 							If $iErr Then
 								$sMessage = 'Error occurred on "' & $sLevel & '" level after processing subframe "' & $sLevel & '/' & $iFrame & '"'

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -939,7 +939,7 @@ Func __WD_FrameList_Internal($sSession, $sLevel, $sFrameAttributes, $bIsHidden, 
 	If $iErr Then
 		$sMessage = 'Error occurred on "' & $sLevel & '" level when trying to entering frame'
 	Else
-		_WD_LoadWait($sSession, 0, $iTimeout, Default, $_WD_READYSTATE_Complete) ; checking if current context is main (top level) __WD_FrameList_Internal() call
+		_WD_LoadWait($sSession, 0, $iTimeout, Default, $_WD_READYSTATE_Complete) ; wait until current frame is fully loaded
 		$iErr = @error
 		If $iErr And $iErr <> $_WD_ERROR_Timeout Then
 			$sMessage = 'Error occurred on "' & $sLevel & '" level when waiting for a browser page load to complete'

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -908,12 +908,12 @@ EndFunc   ;==>_WD_FrameList
 ; #INTERNAL_USE_ONLY# ===========================================================================================================
 ; Name ..........: __WD_FrameList_Internal
 ; Description ...: function that is used internally in _WD_FrameList, even recursively when nested frames are available
-; Syntax ........: __WD_FrameList_Internal($sSession, $sLevel, $sFrameAttributes, $bIsHidden[, $iTimeout = Default])
+; Syntax ........: __WD_FrameList_Internal($sSession, $sLevel, $sFrameAttributes, $bIsHidden, $iTimeout)
 ; Parameters ....: $sSession            - Session ID from _WD_CreateSession
 ;                  $sLevel              - frame location level path
 ;                  $sFrameAttributes    - frame attributes in HTML format
 ;                  $bIsHidden           - information about visibility of frame - taken by WebDriver
-;                  $iTimeout            - [optional] Timeout for _WD_LoadWait() calls for each frame. Default is $_WD_DefaultTimeout
+;                  $iTimeout            - Timeout for _WD_LoadWait() calls for each frame
 ; Return values .: Success - string
 ;                  Failure - "" (empty string) and sets @error returned from related functions
 ; Author ........: mLipok
@@ -923,7 +923,7 @@ EndFunc   ;==>_WD_FrameList
 ; Link ..........:
 ; Example .......: No
 ; ===============================================================================================================================
-Func __WD_FrameList_Internal($sSession, $sLevel, $sFrameAttributes, $bIsHidden, $iTimeout = Default)
+Func __WD_FrameList_Internal($sSession, $sLevel, $sFrameAttributes, $bIsHidden, $iTimeout)
 	Local Const $sFuncName = "__WD_FrameList_Internal"
 	Local Const $sParameters = 'Parameters:    Level=' & $sLevel & '    IsHidden=' & $bIsHidden & '    Timeout=' & $iTimeout ; intentionally $sFrameAttributes is not listed here to not put too many data into the log
 	Local $iErr = $_WD_ERROR_Success, $sMessage = '', $vResult = ''


### PR DESCRIPTION
## Pull request

### Proposed changes
this change give user possibility to provide they own `$iDelay` and `$iTimeout` to have ability to wait for web page will be entirely loaded including all frames.

### Checklist

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

- [ ] Bugfix (change which fixes an issue)
- [x] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

no way to use custom `$iDelay` and `$iTimeout` settings in `_WD_FrameList()` calls

### What is the new behavior?

and now you can do this easily

### Additional context

https://github.com/Danp2/au3WebDriver/issues/420

### System under test

not related
