### PR TITLE
_WD_GetFreePort fixes/improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ Go to [legend](#legend---types-of-changes) for further information about the typ
 	- Refactored for better performance
 	- Improved frame support
 	- Improved logging
+- _WD_GetFreePort
+	- New error code to indicate internal error
+	- Returns starting port number instead of 0 when an error occurs
+	- Improved logging
+- _WD_Startup: Improve logging when error occurs in _WD_GetFreePort
 - Enable optional detailed error reporting
 	- _WD_Attach
 	- _WD_CreateSession

--- a/wd_core.au3
+++ b/wd_core.au3
@@ -1222,6 +1222,8 @@ Func _WD_Startup()
 
 	If $_WD_DRIVER_CLOSE Then __WD_CloseDriver()
 
+	; Attempt to determine the availability of designated port
+	; so that this information can be shown in the logs
 	$sFunction = "_WD_GetFreePort"
 	Call($sFunction, $_WD_PORT)
 

--- a/wd_core.au3
+++ b/wd_core.au3
@@ -1232,9 +1232,11 @@ Func _WD_Startup()
 			; function not available
 
 		Case @error = $_WD_ERROR_GeneralError
+			; unable to obtain port status
 			$sPortAvailable = " (Unknown)"
 
 		Case @error = $_WD_ERROR_NotFound
+			; requested port is unavailable
 			$sPortAvailable = " (Unavailable)"
 	EndSelect
 

--- a/wd_core.au3
+++ b/wd_core.au3
@@ -1229,7 +1229,10 @@ Func _WD_Startup()
 		Case @error = 0xDEAD And @extended = 0xBEEF
 			; function not available
 
-		Case @error
+		Case @error = $_WD_ERROR_GeneralError
+			$sPortAvailable = " (Unknown)"
+
+		Case @error = $_WD_ERROR_NotFound
 			$sPortAvailable = " (Unavailable)"
 	EndSelect
 

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -3221,7 +3221,7 @@ EndFunc   ;==>_WD_JsonActionKey
 Func _WD_GetFreePort($iMinPort = Default, $iMaxPort = Default)
 	Local Const $sFuncName = "_WD_GetFreePort"
 	Local Const $sParameters = 'Parameters:   MinPort=' & $iMinPort & '   MaxPort=' & $iMaxPort
-	Local $sMessage = 'No available ports found'
+	Local $sMessage = ' > No available ports found'
 	
 	If $iMaxPort = Default Then $iMaxPort = ($iMinPort = Default) ? 65000 : $iMinPort
 	If $iMinPort = Default Then $iMinPort = 64000
@@ -3230,7 +3230,7 @@ Func _WD_GetFreePort($iMinPort = Default, $iMaxPort = Default)
 
 	If @error Then
 		$iErr = $_WD_ERROR_GeneralError
-		$sMessage = 'Error occurred in __WinAPI_GetTcpTable'
+		$sMessage = ' > Error occurred in __WinAPI_GetTcpTable'
 	Else
 		For $iPort = $iMinPort To $iMaxPort
 			_ArraySearch($aPorts, $iPort, Default, Default, Default, Default, Default, 3)
@@ -3243,7 +3243,7 @@ Func _WD_GetFreePort($iMinPort = Default, $iMaxPort = Default)
 		Next
 	EndIf
 
-	Return SetError(__WD_Error($sFuncName, $iErr, $sMessage, $iResult), 0, $iResult)
+	Return SetError(__WD_Error($sFuncName, $iErr, $sParameters & $sMessage, $iResult), 0, $iResult)
 EndFunc   ;==>_WD_GetFreePort
 
 Func __WinAPI_GetTcpTable()

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -3221,11 +3221,11 @@ EndFunc   ;==>_WD_JsonActionKey
 Func _WD_GetFreePort($iMinPort = Default, $iMaxPort = Default)
 	Local Const $sFuncName = "_WD_GetFreePort"
 	Local Const $sParameters = 'Parameters:   MinPort=' & $iMinPort & '   MaxPort=' & $iMaxPort
-	Local $iResult = $iMinPort, $iErr = $_WD_ERROR_NotFound
 	Local $sMessage = 'No available ports found'
-
+	
 	If $iMaxPort = Default Then $iMaxPort = ($iMinPort = Default) ? 65000 : $iMinPort
 	If $iMinPort = Default Then $iMinPort = 64000
+	Local $iResult = $iMinPort, $iErr = $_WD_ERROR_NotFound
 	Local $aPorts = __WinAPI_GetTcpTable()
 
 	If @error Then

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -3208,7 +3208,9 @@ EndFunc   ;==>_WD_JsonActionKey
 ; Parameters ....: $iMinPort - [optional] Starting port number. Default is 64000
 ;                  $iMaxPort - [optional] Ending port number. Default is $iMinPort or 65000
 ; Return values .: Success - Available TCP port number
-;                  Failure - 0 and @error set to $_WD_ERROR_NotFound
+;                  Failure - $iMinPort and sets @error to one of the following values:
+;                  - $_WD_ERROR_NotFound
+;                  - $_WD_ERROR_GeneralError
 ; Author ........: Danp2
 ; Modified ......:
 ; Remarks .......:
@@ -3218,24 +3220,30 @@ EndFunc   ;==>_WD_JsonActionKey
 ; ===============================================================================================================================
 Func _WD_GetFreePort($iMinPort = Default, $iMaxPort = Default)
 	Local Const $sFuncName = "_WD_GetFreePort"
-	Local $iResult = 0, $iErr = $_WD_ERROR_NotFound
+	Local Const $sParameters = 'Parameters:   MinPort=' & $iMinPort & '   MaxPort=' & $iMaxPort
+	Local $iResult = $iMinPort, $iErr = $_WD_ERROR_NotFound
+	Local $sMessage = 'No available ports found'
 
 	If $iMaxPort = Default Then $iMaxPort = ($iMinPort = Default) ? 65000 : $iMinPort
 	If $iMinPort = Default Then $iMinPort = 64000
 	Local $aPorts = __WinAPI_GetTcpTable()
 
-	If Not @error Then
+	If @error Then
+		$iErr = $_WD_ERROR_GeneralError
+		$sMessage = 'Error occurred in __WinAPI_GetTcpTable'
+	Else
 		For $iPort = $iMinPort To $iMaxPort
 			_ArraySearch($aPorts, $iPort, Default, Default, Default, Default, Default, 3)
 			If @error = 6 Then
 				$iResult = $iPort
 				$iErr = $_WD_ERROR_Success
+				$sMessage = ''
 				ExitLoop
 			EndIf
 		Next
 	EndIf
 
-	Return SetError(__WD_Error($sFuncName, $iErr, $iResult), 0, $iResult)
+	Return SetError(__WD_Error($sFuncName, $iErr, $sMessage, $iResult), 0, $iResult)
 EndFunc   ;==>_WD_GetFreePort
 
 Func __WinAPI_GetTcpTable()

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -3208,7 +3208,7 @@ EndFunc   ;==>_WD_JsonActionKey
 ; Parameters ....: $iMinPort - [optional] Starting port number. Default is 64000
 ;                  $iMaxPort - [optional] Ending port number. Default is $iMinPort or 65000
 ; Return values .: Success - Available TCP port number
-;                  Failure - $iMinPort and sets @error to one of the following values:
+;                  Failure - Value from $iMinPort and sets @error to one of the following values:
 ;                  - $_WD_ERROR_NotFound
 ;                  - $_WD_ERROR_GeneralError
 ; Author ........: Danp2


### PR DESCRIPTION
## Pull request

### Proposed changes

Implement fixes / improvement to _WD_GetFreePort

### Checklist

Put an `x` in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We are here to help!<br>
This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [x] Bugfix (change which fixes an issue)
- [x] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

- No distinction between error conditions
- Wrong parameters passed to __WD_Error

### What is the new behavior?

- Return separate error code if __WinAPI_GetTcpTable fails
- Return starting port number ($iMinPort) instead of 0 when an error is detected
- Add $sMessage logging
- Fix issue with __WD_Error parameters

### Additional context

Add any other context about the problem here.

### System under test

Please complete the following information.

- OS: [e.g. Windows 10]
- OS Arch.: [e.g. X64]
- Browser [e.g. firefox]
- Browser version [e.g. 96.0.3]
