### PR TITLE
wd_demo.au3 - UserFile() cleaned up

### DIFF
--- a/wd_demo.au3
+++ b/wd_demo.au3
@@ -1137,7 +1137,6 @@ EndFunc   ;==>UserTesting
 #EndRegion - UserTesting
 
 Func UserFile()
-	Local Const $sFuncName = 'UserFile'
 	; Modify the contents of UserTesting.au3 (or create new one) to change the code being executed.
 	; Changes can be made and executed without restarting this script
 	Local $sScriptFileFullPath = FileOpenDialog('Choose testing script', @ScriptDir, 'AutoIt script file (*.au3)', $FD_FILEMUSTEXIST, 'UserTesting.au3')
@@ -1146,9 +1145,7 @@ Func UserFile()
 	Local $aCmds = FileReadToArray($sScriptFileFullPath)
 	If @error Then Return SetError(@error, @extended)
 
-	Local $iLine = 0
 	For $sCmd In $aCmds
-		$iLine += 1
 		; Strip comments
 		; https://www.autoitscript.com/forum/topic/157255-regular-expression-challenge-for-stripping-single-comments/?do=findComment&comment=1138896
 		$sCmd = StringRegExpReplace($sCmd, '(?m)^(?:[^;"'']|''[^'']*''|"[^"]*")*\K;.*', "")


### PR DESCRIPTION
## Pull request

### Proposed changes

cleanup adjustment for Au3Check 

### Checklist

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes
- [ ] Bugfix (change which fixes an issue)
- [ ] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (functional, structural)
- [ ] Documentation content changes
- [x] Other (Au3Check)

### What is the current behavior?

unsed variables are poped up by Au3Check

### What is the new behavior?

all is fine

### Additional context

none

### System under test

not related