### PR TITLE
wd_demo.au3 : $_VAR support in UserFile()

### DIFF
--- a/wd_demo.au3
+++ b/wd_demo.au3
@@ -58,6 +58,7 @@ Global Const $aDebugLevel[][2] = _
 
 Global $sSession
 Global $__g_idButton_Abort
+Global $_VAR[50] ; used in UserFile(),__UserAssing()
 #EndRegion - Global's declarations
 
 _WD_Demo()
@@ -1145,6 +1146,10 @@ Func UserFile()
 	Local $aCmds = FileReadToArray($sScriptFileFullPath)
 	If @error Then Return SetError(@error, @extended)
 
+	Local Const $_VAR_SIZE = UBound($_VAR)
+	ReDim $_VAR[0] ; delete content
+	ReDim $_VAR[$_VAR_SIZE] ; reinitialize size
+
 	For $sCmd In $aCmds
 		; Strip comments
 		; https://www.autoitscript.com/forum/topic/157255-regular-expression-challenge-for-stripping-single-comments/?do=findComment&comment=1138896
@@ -1152,6 +1157,10 @@ Func UserFile()
 		If $sCmd Then Execute($sCmd)
 	Next
 EndFunc   ;==>UserFile
+
+Func __UserAssing($IDX_VAR, $value)
+	$_VAR[$IDX_VAR] = $value
+EndFunc   ;==>__UserAssing
 
 Func _USER_WD_Sleep($iDelay)
 	Local $hTimer = TimerInit() ; Begin the timer and store the handle in a variable.

--- a/wd_demo.au3
+++ b/wd_demo.au3
@@ -1146,8 +1146,8 @@ Func UserFile()
 	Local $aCmds = FileReadToArray($sScriptFileFullPath)
 	If @error Then Return SetError(@error, @extended)
 
-	Local $aEmpty1D[UBound($_VAR)]
-	$_VAR = $aEmpty1D ; CleanUp
+	Local Const $aCleanUP[UBound($_VAR)]
+	$_VAR = $aCleanUP
 
 	For $sCmd In $aCmds
 		; Strip comments

--- a/wd_demo.au3
+++ b/wd_demo.au3
@@ -1146,8 +1146,8 @@ Func UserFile()
 	Local $aCmds = FileReadToArray($sScriptFileFullPath)
 	If @error Then Return SetError(@error, @extended)
 
-	Local Const $aCleanUP[UBound($_VAR)] = []
-	$_VAR = $aCleanUP
+	Local Const $aEmpty1D[UBound($_VAR)] = []
+	$_VAR = $aEmpty1D ; clean up the globally declared $_VAR to ensure repeatable test conditions
 
 	For $sCmd In $aCmds
 		; Strip comments

--- a/wd_demo.au3
+++ b/wd_demo.au3
@@ -1146,9 +1146,8 @@ Func UserFile()
 	Local $aCmds = FileReadToArray($sScriptFileFullPath)
 	If @error Then Return SetError(@error, @extended)
 
-	Local Const $_VAR_SIZE = UBound($_VAR)
-	ReDim $_VAR[0] ; delete content
-	ReDim $_VAR[$_VAR_SIZE] ; reinitialize size
+	Local $aEmpty1D[UBound($_VAR)]
+	$_VAR = $aEmpty1D ; CleanUp
 
 	For $sCmd In $aCmds
 		; Strip comments

--- a/wd_demo.au3
+++ b/wd_demo.au3
@@ -58,7 +58,7 @@ Global Const $aDebugLevel[][2] = _
 
 Global $sSession
 Global $__g_idButton_Abort
-Global $_VAR[50] ; used in UserFile(),__UserAssing()
+Global $_VAR[50] ; used in UserFile(),__UserAssign()
 #EndRegion - Global's declarations
 
 _WD_Demo()
@@ -1158,9 +1158,9 @@ Func UserFile()
 	Next
 EndFunc   ;==>UserFile
 
-Func __UserAssing($IDX_VAR, $value)
+Func __UserAssign($IDX_VAR, $value)
 	$_VAR[$IDX_VAR] = $value
-EndFunc   ;==>__UserAssing
+EndFunc   ;==>__UserAssign
 
 Func _USER_WD_Sleep($iDelay)
 	Local $hTimer = TimerInit() ; Begin the timer and store the handle in a variable.

--- a/wd_demo.au3
+++ b/wd_demo.au3
@@ -1146,7 +1146,7 @@ Func UserFile()
 	Local $aCmds = FileReadToArray($sScriptFileFullPath)
 	If @error Then Return SetError(@error, @extended)
 
-	Local Const $aCleanUP[UBound($_VAR)]
+	Local Const $aCleanUP[UBound($_VAR)] = []
 	$_VAR = $aCleanUP
 
 	For $sCmd In $aCmds


### PR DESCRIPTION
## Pull request

### Proposed changes

user using `UserTesting()` with `UserTesting.au3` should have ability to set values for variables, this is limited as `Execute()` have their specific usage, and given this particular need, one could even say that it is a limitation, which can be tested with this following snippet which shows that `$b` is not set to 1 as `Execute()` evaluates expression and return results from this evalutation.
```autoit
Local $a = 1
Local $v = Execute("$a+1") ; $v is set to 2
ConsoleWrite("$v=" & $v & @CRLF)

Local $b
Execute("$b=1")
ConsoleWrite("$b=" & $b & @CRLF)

Local $c
ConsoleWrite(Execute("$c=1") & @CRLF)
```

### Checklist

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

- [ ] Bugfix (change which fixes an issue)
- [x] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

description in: https://github.com/Danp2/au3WebDriver/issues/461

### What is the new behavior?

It is possible to use such `UserTesting.au3`:

```autoit
__UserAssign(0, 'Absolute Identifiers > _WD_FrameEnter|Relative Identifiers > _WD_FrameEnter|FRAME attributes|URL|Body ElementID|IsHidden|MatchedElements')

_Demo_NavigateCheckBanner($sSession, "https://www.w3schools.com/tags/tryit.asp?filename=tryhtml_iframe", '//*[@id="snigel-cmp-framework" and @class="snigel-cmp-framework"]')
ConsoleWrite("! 1" & @CRLF)

__UserAssign(1, _WD_GetContext($sSession))
ConsoleWrite("! 2" & $_VAR[1] & @CRLF)

__UserAssign(2, _WD_FrameList($sSession))

ConsoleWrite("! 3" & @CRLF)

_ArrayDisplay($_VAR[2], 'Starting', 0, 0, Default, $_VAR[0])
ConsoleWrite("! 4 - _ArrayDisplay" & @CRLF)

_WD_FrameEnter($sSession, 'null/0')
ConsoleWrite("! 5" & @CRLF)

__UserAssign(3, _WD_FrameList($sSession))
ConsoleWrite("! 6" & @CRLF)

_ArrayDisplay($_VAR[3], 'null/0', 0, 0, Default, $_VAR[0])
ConsoleWrite("! 7 - _ArrayDisplay" & @CRLF)

_WD_FrameEnter($sSession, $CONTEXT)
ConsoleWrite("! 8" & @CRLF)

__UserAssign(4, _WD_FrameList($sSession))
ConsoleWrite("! 9" & @CRLF)

_ArrayDisplay($_VAR[4], '$CONTEXT', 0, 0, Default, $_VAR[0])
ConsoleWrite("! 10 - _ArrayDisplay" & @CRLF)
```

The main benefit of this modification is that you can test user code on the run without having to close `wd_demo.au3` and more importantly without having to close the compiled version `wd_demo.exe`, so you can test a given script modification without having to install the test environment for AutoIt+SciTE.

### Additional context

https://github.com/Danp2/au3WebDriver/issues/461

### System under test

not related
