### PR TITLE
_WD_FrameList - $bReturnAsArray fix

### DIFF
--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -868,23 +868,24 @@ Func _WD_FrameList($sSession, $bReturnAsArray = True, $iDelay = 1000, $iTimeout 
 			; recalculate locations from absolute path on COL0 to relative path on COL1
 			$a_Result[$i][$_WD_FRAMELIST_Relative] = StringRegExpReplace($a_Result[$i][$_WD_FRAMELIST_Absolute], '\A' & $sStartLocation & '\/?', '')
 		Next
-		$iFrameCount = UBound($a_Result, $UBOUND_ROWS)
-		If $iFrameCount < 1 Then $sMessage &= 'List of frames is empty. '
-
-		; select desired DataType for the $vResult - usually string is option for testing and asking support, thus Array is returned by default
-		If $bReturnAsArray Then
-			$vResult = $a_Result
-		Else
-			$vResult = _ArrayToString($a_Result) ; getting string with recalculated locations (relative path)
-			If @error Then
-				$iErr = $_WD_ERROR_RetValue
-				$sMessage = 'ArrayToString conversion failed. '
-				$vResult = ''
-			EndIf
-		EndIf
 
 	ElseIf $iErr <> $_WD_ERROR_Timeout And $iErr <> $_WD_ERROR_UserAbort And Not $_WD_DetailedErrors Then
 		$iErr = $_WD_ERROR_GeneralError
+	EndIf
+
+	$iFrameCount = UBound($a_Result, $UBOUND_ROWS)
+	If $iFrameCount < 1 Then $sMessage &= 'List of frames is empty. '
+
+	; select desired DataType for the $vResult - usually string is option for testing and asking support, thus Array is returned by default
+	If $bReturnAsArray Then
+		$vResult = $a_Result
+	Else
+		$vResult = _ArrayToString($a_Result) ; getting string with recalculated locations (relative path)
+		If @error Then
+			$iErr = $_WD_ERROR_RetValue
+			$sMessage = 'ArrayToString conversion failed. '
+			$vResult = ''
+		EndIf
 	EndIf
 
 	If $sStartLocation Then ; Back to "calling frame"


### PR DESCRIPTION
## Pull request

### Proposed changes

If `$bReturnAsArray=True`  then even if third `__WD_FrameList_Internal` iteration will fire error then it returs string which should be converted to array

### Checklist

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

- [x] Bugfix (change which fixes an issue)
- [ ] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

if some `__WD_FrameList_Internal` iteration will fire error then string will be returned even if `$bReturnAsArray=True`  was requested


### What is the new behavior?
Proper Array

### Additional context
I hit this error when testing:
https://github.com/Danp2/au3WebDriver/pull/462

### System under test
not related