### PR TITLE
wd_demo.au3 - ability to repeat "UserFile" processing

### DIFF
--- a/usertesting.au3
+++ b/usertesting.au3
@@ -1,8 +1,6 @@
 ; The contents of this file are read & executed by the UserFile() function in wd_demo.au3
-;
 ; Changes can be made to this file and quickly tested without having to exit or even close browser
 ConsoleWrite("! Code now executing from usertesting.au3" & @CRLF)
-
 
 ConsoleWrite("- Test 1:" & @CRLF)
 _WD_NewTab($sSession, False, Default, "https://www.chrome.com", "noreferrer")
@@ -13,7 +11,7 @@ ConsoleWrite("- Test 2:" & @CRLF)
 _WD_NewTab($sSession, True)
 _WD_Navigate($sSession, 'https://www.google.com')
 _WD_LoadWait($sSession)
-MsgBox($MB_OK + $MB_TOPMOST + $MB_ICONWARNING, "Warrning #" & @ScriptLineNumber, "If you see COOKIE accept panel close them before you will continue.")
+MsgBox($MB_OK + $MB_TOPMOST + $MB_ICONWARNING, "Warning #" & @ScriptLineNumber, "If you see COOKIE accept panel close them before you will continue.")
 
 ConsoleWrite("- Test 3:" & @CRLF)
 ; REMARK:  __SetVAR($IDX_VAR, $value) will set  $_VAR[$IDX_VAR] = $value

--- a/usertesting.au3
+++ b/usertesting.au3
@@ -1,17 +1,28 @@
-; The contents of this file are read & executed by the UserFile function in wd_demo.au3
+; The contents of this file are read & executed by the UserFile() function in wd_demo.au3
 ;
-; Changes can be made to this file and quickly tested without having to exit and 
-; relaunch wd_demo.au3
+; Changes can be made to this file and quickly tested without having to exit or even close browser
 ConsoleWrite("! Code now executing from usertesting.au3" & @CRLF)
 
-_WD_Navigate($sSession, 'https://www.google.com')
-_WD_LoadWait($sSession)
 
 ConsoleWrite("- Test 1:" & @CRLF)
 _WD_NewTab($sSession, False, Default, "https://www.chrome.com", "noreferrer")
 _WD_Attach($sSession, "Chrome")
 _WD_LoadWait($sSession, 1000)
-_WD_FindElement($sSession, $_WD_LOCATOR_ByXPath, "//input[@title='Search']")
 
 ConsoleWrite("- Test 2:" & @CRLF)
+_WD_NewTab($sSession, True)
+_WD_Navigate($sSession, 'https://www.google.com')
+_WD_LoadWait($sSession)
+MsgBox($MB_OK + $MB_TOPMOST + $MB_ICONWARNING, "Warrning #" & @ScriptLineNumber, "If you see COOKIE accept panel close them before you will continue.")
+
+ConsoleWrite("- Test 3:" & @CRLF)
+; REMARK:  __SetVAR($IDX_VAR, $value) will set  $_VAR[$IDX_VAR] = $value
+__SetVAR(0, _WD_FindElement($sSession, $_WD_LOCATOR_ByXPath, "//textarea[@name='q']"))
+
+ConsoleWrite("- Test 4:" & @CRLF)
+_WD_ElementAction($sSession, $_VAR[0], "VALUE", 'AutoIt Forum')
+
+ConsoleWrite("- Test 5:" & @CRLF)
 _WD_WaitElement($sSession, $_WD_LOCATOR_ByCSSSelector, '#fake', 1000, 3000, $_WD_OPTION_NoMatch)
+
+ConsoleWrite("! End of processing usertesting.au3" & @CRLF)

--- a/wd_demo.au3
+++ b/wd_demo.au3
@@ -1159,7 +1159,7 @@ Func UserFile()
 			If $sCmd Then Execute($sCmd)
 		Next
 
-	Until $IDNO = MsgBox($MB_YESNO + $MB_TOPMOST + $MB_ICONQUESTION + $MB_DEFBUTTON2, 'Question', 'Do you want to repeat "UserFile" processing ?')
+	Until $IDNO = MsgBox($MB_YESNO + $MB_TOPMOST + $MB_ICONQUESTION + $MB_DEFBUTTON2, 'Question', 'Do you want to process another file?')
 
 EndFunc   ;==>UserFile
 

--- a/wd_demo.au3
+++ b/wd_demo.au3
@@ -58,7 +58,7 @@ Global Const $aDebugLevel[][2] = _
 
 Global $sSession
 Global $__g_idButton_Abort
-Global $_VAR[50] ; used in UserFile(),__UserAssign()
+Global $_VAR[50] ; used in UserFile(), __SetVAR()
 #EndRegion - Global's declarations
 
 _WD_Demo()
@@ -1139,27 +1139,34 @@ EndFunc   ;==>UserTesting
 
 Func UserFile()
 	; Modify the contents of UserTesting.au3 (or create new one) to change the code being executed.
-	; Changes can be made and executed without restarting this script
-	Local $sScriptFileFullPath = FileOpenDialog('Choose testing script', @ScriptDir, 'AutoIt script file (*.au3)', $FD_FILEMUSTEXIST, 'UserTesting.au3')
-	If @error Then Return SetError(@error, @extended)
-
-	Local $aCmds = FileReadToArray($sScriptFileFullPath)
-	If @error Then Return SetError(@error, @extended)
-
+	; Changes can be made and executed without restarting this script,
+	;	you can even repeat "UserFile" processing without closing browser
 	Local Const $aEmpty1D[UBound($_VAR)] = []
-	$_VAR = $aEmpty1D ; clean up the globally declared $_VAR to ensure repeatable test conditions
+	Local $sScriptFileFullPath, $aCmds
 
-	For $sCmd In $aCmds
-		; Strip comments
-		; https://www.autoitscript.com/forum/topic/157255-regular-expression-challenge-for-stripping-single-comments/?do=findComment&comment=1138896
-		$sCmd = StringRegExpReplace($sCmd, '(?m)^(?:[^;"'']|''[^'']*''|"[^"]*")*\K;.*', "")
-		If $sCmd Then Execute($sCmd)
-	Next
+	Do
+		$_VAR = $aEmpty1D ; clean up the globally declared $_VAR to ensure repeatable test conditions
+		$sScriptFileFullPath = FileOpenDialog('Choose testing script', @ScriptDir, 'AutoIt script file (*.au3)', $FD_FILEMUSTEXIST, 'UserTesting.au3')
+		If @error Then Return SetError(@error, @extended)
+
+		$aCmds = FileReadToArray($sScriptFileFullPath)
+		If @error Then Return SetError(@error, @extended)
+
+		For $sCmd In $aCmds
+			; Strip comments
+			; https://www.autoitscript.com/forum/topic/157255-regular-expression-challenge-for-stripping-single-comments/?do=findComment&comment=1138896
+			$sCmd = StringRegExpReplace($sCmd, '(?m)^(?:[^;"'']|''[^'']*''|"[^"]*")*\K;.*', "")
+			If $sCmd Then Execute($sCmd)
+		Next
+
+	Until $IDNO = MsgBox($MB_YESNO + $MB_TOPMOST + $MB_ICONQUESTION + $MB_DEFBUTTON2, 'Question', 'Do you want to repeat "UserFile" processing ?')
+
 EndFunc   ;==>UserFile
 
-Func __UserAssign($IDX_VAR, $value)
+Func __SetVAR($IDX_VAR, $value)
 	$_VAR[$IDX_VAR] = $value
-EndFunc   ;==>__UserAssign
+	ConsoleWrite('- Setting $_VAR[' & $IDX_VAR & '] = ' & ((IsArray($value)) ? ('{array}') : ($value)) & @CRLF)
+EndFunc   ;==>__SetVAR
 
 Func _USER_WD_Sleep($iDelay)
 	Local $hTimer = TimerInit() ; Begin the timer and store the handle in a variable.


### PR DESCRIPTION
## Pull request

### Proposed changes

As I mention before: https://github.com/Danp2/au3WebDriver/pull/462#issuecomment-1522290146

### Checklist

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes
- [ ] Bugfix (change which fixes an issue)
- [x] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

`UserFile()` process `UserTesting.au3` only once and after processing close browser

### What is the new behavior?

You can choose new or the same `UserTesting.au3` and process them again without closing browser.


### Additional context

Was tested with `usertesting.au3` modified with this PR, and with separate `usertesting_WD_GetContext.au3` which contains:
```autoit
ConsoleWrite("! START" & @CRLF)

__SetVAR(0, "Absolute Identifiers > _WD_FrameEnter|Relative Identifiers > _WD_FrameEnter|IFRAME/FRAME attributes|URL|Body ElementID|IsHidden|MatchedElements")
ConsoleWrite("! 0 - $_VAR[0] = " & $_VAR[0] & @CRLF)

_Demo_NavigateCheckBanner($sSession, "https://www.w3schools.com/tags/tryit.asp?filename=tryhtml_iframe", '//*[@id="snigel-cmp-framework" and @class="snigel-cmp-framework"]')
ConsoleWrite("! 1" & @CRLF)

__SetVAR(1, _WD_GetContext($sSession))
ConsoleWrite("! 2 _WD_GetContext >> " & $_VAR[1] & @CRLF)

__SetVAR(2, _WD_FrameList($sSession))
ConsoleWrite("! 3" & @CRLF)

_ArrayDisplay($_VAR[2], 'Starting', 0, 0, Default, $_VAR[0])
ConsoleWrite("! 4 - _ArrayDisplay" & @CRLF)

_WD_FrameEnter($sSession, 'null/0')
ConsoleWrite("! 5" & @CRLF)

__SetVAR(3, _WD_FrameList($sSession))
ConsoleWrite("! 6" & @CRLF)

_ArrayDisplay($_VAR[3], 'null/0', 0, 0, Default, $_VAR[0])
ConsoleWrite("! 7 - _ArrayDisplay" & @CRLF)

_WD_FrameEnter($sSession, $_VAR[1])
ConsoleWrite("! 8 after entering frame taken from _WD_GetContext()" & @CRLF)

__SetVAR(4, _WD_FrameList($sSession))
ConsoleWrite("! 9" & @CRLF)

_ArrayDisplay($_VAR[4], 'relative CONTEXT = ' & $_VAR[1], 0, 0, Default, $_VAR[0])
ConsoleWrite("! 10 - _ArrayDisplay" & @CRLF)
```

### System under test
not related