### PR TITLE
_WD_SetElementValue - Add remark

### DIFF
--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -2589,7 +2589,8 @@ EndFunc   ;==>_WD_GetElementByName
 ;                  - $_WD_ERROR_InvalidExpression
 ; Author ........: Danp2
 ; Modified ......: mLipok, TheDcoder
-; Remarks .......:
+; Remarks .......: When using Advanced mode, translations or string encoding should occur prior to
+;                  calling this function because the supplied value is used without modification.
 ; Related .......: _WD_ElementAction, _WD_LastHTTPResult
 ; Link ..........:
 ; Example .......: No


### PR DESCRIPTION
## Pull request

### Proposed changes

Closes #466 

### Checklist

Put an `x` in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We are here to help!<br>
This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [ ] Bugfix (change which fixes an issue)
- [ ] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [x] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

When using $_WD_OPTION_Advanced in _WD_SetElementValue, $sValue is not escaped

### What is the new behavior?

Behavior is unchanged. Added remark to document that the user is responsible for formatting the data prior to calling _WD_SetElementValue in Advanced mode.

### Additional context

Add any other context about the problem here.

### System under test

Please complete the following information.

- OS: [e.g. Windows 10]
- OS Arch.: [e.g. X64]
- Browser [e.g. firefox]
- Browser version [e.g. 96.0.3]
