### PR TITLE
Fix error in _WD_FrameEnter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Go to [legend](#legend---types-of-changes) for further information about the types of changes.
 
-## [Unreleased]
+## [1.0.1] 2023-05-23
+
+### Fixed
+
+- _WD_FrameEnter: Remove GUID validation
 
 ### Project
 
@@ -1090,7 +1094,8 @@ _WD_CapabilitiesDisplay
 - Initial release
 
 
-[Unreleased]: https://github.com/Danp2/au3WebDriver/compare/1.0.0...HEAD
+[Unreleased]: https://github.com/Danp2/au3WebDriver/compare/1.0.1...HEAD
+[1.0.1]:     https://github.com/Danp2/au3WebDriver/compare/1.0.0...1.0.1
 [1.0.0]:     https://github.com/Danp2/au3WebDriver/compare/0.13.0...1.0.0
 [0.13.0]:     https://github.com/Danp2/au3WebDriver/compare/0.12.0...0.13.0
 [0.12.0]:     https://github.com/Danp2/au3WebDriver/compare/0.11.0...0.12.0

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -703,7 +703,6 @@ EndFunc   ;==>_WD_IsWindowTop
 ; Return values .: Success - True.
 ;                  Failure - WD Response error message (E.g. "no such frame") and sets @error to one of the following values:
 ;                  - $_WD_ERROR_Exception
-;                  - $_WD_ERROR_InvalidArgue
 ; Author ........: Decibel
 ; Modified ......: Danp2, mLipok, jchd
 ; Remarks .......: You can drill-down into nested frames by calling this function repeatedly or use identifier like 'null/2/0'
@@ -729,34 +728,27 @@ Func _WD_FrameEnter($sSession, $vIdentifier)
 	ElseIf IsInt($vIdentifier) Then
 		$sOption = '{"id":' & $vIdentifier & '}'
 	Else
-		_WinAPI_GUIDFromString("{" & $vIdentifier & "}")
-		If @error Then
-			$iErr = $_WD_ERROR_InvalidArgue
-		Else
-			$sOption = '{"id":' & __WD_JsonElement($vIdentifier) & '}'
-		EndIf
+		$sOption = '{"id":' & __WD_JsonElement($vIdentifier) & '}'
 	EndIf
 
-	If $iErr = $_WD_ERROR_Success Then ; check if $vIdentifier was succesfully validated
-		If Not $bIdentifierAsPath Then
-			$sResponse = _WD_Window($sSession, "frame", $sOption)
-			$iErr = @error
-		Else
-			Local $aIdentifiers = StringSplit($vIdentifier, '/')
-			For $i = 1 To $aIdentifiers[0]
-				If String($aIdentifiers[$i]) = 'null' Then
-					$aIdentifiers[$i] = '{"id":null}'
-				Else
-					$aIdentifiers[$i] = '{"id":' & $aIdentifiers[$i] & '}'
-				EndIf
-				$sResponse = _WD_Window($sSession, "frame", $aIdentifiers[$i])
-				If Not @error Then ContinueLoop
+	If Not $bIdentifierAsPath Then
+		$sResponse = _WD_Window($sSession, "frame", $sOption)
+		$iErr = @error
+	Else
+		Local $aIdentifiers = StringSplit($vIdentifier, '/')
+		For $i = 1 To $aIdentifiers[0]
+			If String($aIdentifiers[$i]) = 'null' Then
+				$aIdentifiers[$i] = '{"id":null}'
+			Else
+				$aIdentifiers[$i] = '{"id":' & $aIdentifiers[$i] & '}'
+			EndIf
+			$sResponse = _WD_Window($sSession, "frame", $aIdentifiers[$i])
+			If Not @error Then ContinueLoop
 
-				$iErr = @error
-				$sMessage = ' Error on ID#' & $i & ' > ' & $aIdentifiers[$i]
-				ExitLoop
-			Next
-		EndIf
+			$iErr = @error
+			$sMessage = ' Error on ID#' & $i & ' > ' & $aIdentifiers[$i]
+			ExitLoop
+		Next
 	EndIf
 
 	If $iErr = $_WD_ERROR_Success Then
@@ -769,7 +761,7 @@ Func _WD_FrameEnter($sSession, $vIdentifier)
 		Else
 			$sValue = True
 		EndIf
-	ElseIf $iErr <> $_WD_ERROR_InvalidArgue And Not $_WD_DetailedErrors Then
+	ElseIf Not $_WD_DetailedErrors Then
 		$iErr = $_WD_ERROR_Exception
 	EndIf
 


### PR DESCRIPTION
## Pull request

### Proposed changes

Removes invalid check for _WinAPI_GUIDFromString; fixes #474 

### Checklist

Put an `x` in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We are here to help!<br>
This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [x] Bugfix (change which fixes an issue)
- [ ] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

_WD_FrameEnter incorrectly returns invalid argument when using Chrome or MSEdge

### What is the new behavior?

Eliminate GUID check and special processing for $_WD_ERROR_InvalidArgue

### Additional context



### System under test

- Chrome and MSEdge