### PR TITLE
Fix _WD_GetElementFromPoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Go to [legend](#legend---types-of-changes) for further information about the types of changes.
 
+## [Unreleased]
+
+### Fixed
+
+- _WD_GetElementFromPoint
+	- Correct frame identification
+	- Handle Null result from `document.elementFromPoint`
+
 ## [1.0.2] 2023-05-24
 
 ### Fixed

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -639,7 +639,7 @@ Func _WD_GetElementFromPoint($sSession, $iX, $iY)
 			ExitLoop
 		Else
 			$sTagName = _WD_ElementAction($sSession, $sElement, "Name")
-			If Not StringInStr("frame", $sTagName) Then ; check <iframe> and <frame> element
+			If Not StringInStr($sTagName, "frame") Then ; check <iframe> and <frame> element
 				ExitLoop
 			EndIf
 			

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -633,7 +633,7 @@ Func _WD_GetElementFromPoint($sSession, $iX, $iY)
 			$bIsNull = (IsKeyword($sResult) = $KEYWORD_NULL)
 
 			If Not $bIsNull Then
-				$iErr = $_WD_ERROR_RetValue			
+				$iErr = $_WD_ERROR_RetValue
 			EndIf
 
 			ExitLoop
@@ -642,22 +642,22 @@ Func _WD_GetElementFromPoint($sSession, $iX, $iY)
 			If Not StringInStr($sTagName, "frame") Then ; check <iframe> and <frame> element
 				ExitLoop
 			EndIf
-			
+
 			$aCoords = _WD_ExecuteScript($sSession, $sScript2, $_WD_EmptyDict, Default, $_WD_JSON_Value)
 			If @error Then
 				$iErr = $_WD_ERROR_RetValue
 				ExitLoop
 			EndIf
-			
+
 			$oERect = _WD_ElementAction($sSession, $sElement, 'rect')
-			
+
 			; changing the coordinates in relation to left top corner of frame
 			$iX -= ($oERect.Item('x') - Int($aCoords[0]))
 			$iY -= ($oERect.Item('y') - Int($aCoords[1]))
-			
+
 			_WD_FrameEnter($sSession, $sElement)
 			$iFrame = 1
-		Endif
+		EndIf
 	WEnd
 
 	Return SetError(__WD_Error($sFuncName, $iErr, $sParameters, $iFrame), $iFrame, $sElement)
@@ -1957,7 +1957,7 @@ EndFunc   ;==>_WD_GetShadowRoot
 Func _WD_SelectFiles($sSession, $sStrategy, $sSelector, $sFilename)
 	Local Const $sFuncName = "_WD_SelectFiles"
 	Local Const $sParameters = 'Parameters:    Strategy=' & $sStrategy & '    Selector=' & $sSelector & '    Filename=' & $sFilename
-	Local $sResult = "0", $sSavedEscape
+	Local $sResult = "0"
 	Local $sElement = _WD_FindElement($sSession, $sStrategy, $sSelector)
 	Local $iErr = @error
 


### PR DESCRIPTION
## Pull request

### Proposed changes

- Properly handle when script execution returns Null value
- Correct identification of frames

### Checklist

Put an `x` in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We are here to help!<br>
This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [x] Bugfix (change which fixes an issue)
- [ ] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

- Incorrect string comparison
- Error improperly detected when `document.elementFromPoint` returns `Null`

### What is the new behavior?

- Return empty string when  `document.elementFromPoint` returns `Null` without setting @<!-- -->error
- Correctly identify frame/iframe elements

### Additional context

Add any other context about the problem here.

### System under test

Please complete the following information.

- OS: [e.g. Windows 10]
- OS Arch.: [e.g. X64]
- Browser [e.g. firefox]
- Browser version [e.g. 96.0.3]
