### PR TITLE
chrome >> chrome_legacy - automatically supported

### DIFF
--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -2081,7 +2081,7 @@ Func _WD_UpdateDriver($sBrowser, $sInstallDir = Default, $bFlag64 = Default, $bF
 		If $iErr = $_WD_ERROR_Success Then
 			Local $iIndex = @extended
 			If $sBrowser = "chrome" Then
-				Local $i_Check = (_VersionCompare("115.0.0.0", $sBrowserVersion)
+				Local $i_Check = _VersionCompare("115.0.0.0", $sBrowserVersion)
 				If Not @error And $i_Check = 1 Then $sBrowser = "chrome_legacy"
 			EndIf
 			; Match exe file name in list of supported browsers

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -2077,13 +2077,16 @@ Func _WD_UpdateDriver($sBrowser, $sInstallDir = Default, $bFlag64 = Default, $bF
 		$sBrowserVersion = _WD_GetBrowserVersion($sBrowser)
 		$iErr = @error
 		$iExt = @extended
+		If $sBrowser = "chrome" Then
+			Local $i_Check = _VersionCompare("115.0.0.0", $sBrowserVersion)
+			If Not @error And $i_Check = 1 Then $sBrowser = "chrome_legacy"
+			$sBrowserVersion = _WD_GetBrowserVersion($sBrowser)
+			$iErr = @error
+			$iExt = @extended
+		EndIf
 
 		If $iErr = $_WD_ERROR_Success Then
 			Local $iIndex = @extended
-			If $sBrowser = "chrome" Then
-				Local $i_Check = _VersionCompare("115.0.0.0", $sBrowserVersion)
-				If Not @error And $i_Check = 1 Then $sBrowser = "chrome_legacy"
-			EndIf
 			; Match exe file name in list of supported browsers
 			$sDriverEXE = $_WD_SupportedBrowsers[$iIndex][$_WD_BROWSER_DriverName]
 

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -2080,6 +2080,10 @@ Func _WD_UpdateDriver($sBrowser, $sInstallDir = Default, $bFlag64 = Default, $bF
 
 		If $iErr = $_WD_ERROR_Success Then
 			Local $iIndex = @extended
+			If $sBrowser = "chrome" Then
+				Local $i_Check = (_VersionCompare("115.0.0.0", $sBrowserVersion)
+				If Not @error And $i_Check = 1 Then $sBrowser = "chrome_legacy"
+			EndIf
 			; Match exe file name in list of supported browsers
 			$sDriverEXE = $_WD_SupportedBrowsers[$iIndex][$_WD_BROWSER_DriverName]
 

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -2075,15 +2075,13 @@ Func _WD_UpdateDriver($sBrowser, $sInstallDir = Default, $bFlag64 = Default, $bF
 		If $_WD_DEBUG <> $_WD_DEBUG_Full Then $_WD_DEBUG = $_WD_DEBUG_None
 
 		$sBrowserVersion = _WD_GetBrowserVersion($sBrowser)
-		$iErr = @error
-		$iExt = @extended
-		If $sBrowser = "chrome" Then
+		If Not @error And $sBrowser = "chrome" Then
 			Local $i_Check = _VersionCompare("115.0.0.0", $sBrowserVersion)
 			If Not @error And $i_Check = 1 Then $sBrowser = "chrome_legacy"
 			$sBrowserVersion = _WD_GetBrowserVersion($sBrowser)
-			$iErr = @error
-			$iExt = @extended
 		EndIf
+		$iErr = @error
+		$iExt = @extended
 
 		If $iErr = $_WD_ERROR_Success Then
 			Local $iIndex = @extended


### PR DESCRIPTION
## Pull request

### Proposed changes

chrome >> chrome_legacy - should be automatically supported user should not bother about this

### Checklist

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

- [ ] Bugfix (change which fixes an issue)
- [x] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

you need to check which version of Chrome browser you have and specify this by choosing **chrome** or **chrome_legacy** 

### What is the new behavior?

chrome >> chrome_legacy - automatically done

### Additional context

https://www.autoitscript.com/forum/topic/208640-webdriver-udf-help-support-iv/?do=findComment&comment=1521299

https://www.autoitscript.com/forum/topic/208640-webdriver-udf-help-support-iv/?do=findComment&comment=1521377

### System under test
Chrome Browser v114... v115


### REMARK
consider to check for `$_WD_SupportedBrowsers` if there is a need to add accordingly some additionall checking 