### PR TITLE
_WD_ExecuteScript: don't reformat JS code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Go to [legend](#legend---types-of-changes) for further information about the typ
 
 ## [Unreleased]
 
+### Fixed
+
+_WD_ExecuteScript: Eliminate reformatting of JS code
+
 ### Changed
 
 - _WD_GetTable

--- a/wd_core.au3
+++ b/wd_core.au3
@@ -896,7 +896,7 @@ Func _WD_ExecuteScript($sSession, $sScript, $sArguments = Default, $bAsync = Def
 	If IsBool($vSubNode) Then $vSubNode = ($vSubNode) ? $_WD_JSON_Value : "" ; True = the JSON value node is returned , False = entire JSON response is returned
 
 	If IsString($vSubNode) Then
-		$sScript = __WD_EscapeString($sScript, $JSON_MLREFORMAT)
+		$sScript = __WD_EscapeString($sScript)
 
 		$sData = '{"script":"' & $sScript & '", "args":[' & $sArguments & ']}'
 		$sCmd = ($bAsync) ? 'async' : 'sync'

--- a/wd_core.au3
+++ b/wd_core.au3
@@ -1736,7 +1736,7 @@ EndFunc   ;==>__WD_CloseDriver
 ;                  $iOption - [optional] Any combination of $JSON_* constants. Default is 0.
 ; Author ........: Danp2
 ; Modified ......:
-; Remarks .......:
+; Remarks .......:  See $JSON_* constants in json.au3 for the possible $iOption combinations.
 ; Related .......:
 ; Link ..........:
 ; Example .......: No

--- a/wd_core.au3
+++ b/wd_core.au3
@@ -1734,6 +1734,8 @@ EndFunc   ;==>__WD_CloseDriver
 ; Syntax ........: __WD_EscapeString($sData[, $iOption = 0])
 ; Parameters ....: $sData   - the string to be escaped
 ;                  $iOption - [optional] Any combination of $JSON_* constants. Default is 0.
+; Return values..: Success - Escaped string
+;                  Failure - Response from JSON UDF and sets @error to $_WD_ERROR_GeneralError
 ; Author ........: Danp2
 ; Modified ......:
 ; Remarks .......:  See $JSON_* constants in json.au3 for the possible $iOption combinations.
@@ -1742,9 +1744,11 @@ EndFunc   ;==>__WD_CloseDriver
 ; Example .......: No
 ; ===============================================================================================================================
 Func __WD_EscapeString($sData, $iOption = 0)
+	Local $iErr = $_WD_ERROR_Success
 	$sData = Json_StringEncode($sData, $iOption) ; Escape JSON Strings
 
-	Return SetError($_WD_ERROR_Success, 0, $sData)
+	If @error Then $iErr = $_WD_ERROR_GeneralError
+	Return SetError($iErr, 0, $sData)
 EndFunc   ;==>__WD_EscapeString
 
 ; #INTERNAL_USE_ONLY# ===========================================================================================================

--- a/wd_core.au3
+++ b/wd_core.au3
@@ -88,8 +88,6 @@ Global Const $_WD_JSON_Shadow = "[value][" & $_WD_SHADOW_ID & "]"
 Global Const $_WD_JSON_Error = "[value][error]"
 Global Const $_WD_JSON_Message = "[value][message]"
 
-Global Const $JSON_MLREFORMAT = 1048576 ; Addition to constants from json.au3
-
 Global Enum _
 		$_WD_DEBUG_None = 0, _ ; No logging
 		$_WD_DEBUG_Error, _    ; logging in case of Error
@@ -1738,18 +1736,12 @@ EndFunc   ;==>__WD_CloseDriver
 ;                  $iOption - [optional] Any combination of $JSON_* constants. Default is 0.
 ; Author ........: Danp2
 ; Modified ......:
-; Remarks .......: $JSON_MLREFORMAT will strip tabs and CR/LFs from a multiline string.
-;                  See $JSON_* constants in json.au3 for other $iOption possibilities.
+; Remarks .......:
 ; Related .......:
 ; Link ..........:
 ; Example .......: No
 ; ===============================================================================================================================
 Func __WD_EscapeString($sData, $iOption = 0)
-	If BitAND($iOption, $JSON_MLREFORMAT) Then
-		$sData = StringRegExpReplace($sData, '[\v\t]', '') ; Strip tabs and CR/LFs
-		$iOption = BitXOR($iOption, $JSON_MLREFORMAT)      ; Flip bit off
-	EndIf
-
 	$sData = Json_StringEncode($sData, $iOption) ; Escape JSON Strings
 
 	Return SetError($_WD_ERROR_Success, 0, $sData)


### PR DESCRIPTION
## Pull request

### Proposed changes

Fixes #487 

### Checklist

Put an `x` in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We are here to help!<br>
This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [x] Bugfix (change which fixes an issue)
- [ ] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

Stripping of tabs and spaces from JS can result in code that no longer functions properly.

### What is the new behavior?

Code is processed as-is. Any reformatting that is required should be performed prior to calling _WD_ExecuteScript

### Additional context



### System under test

