### PR TITLE
Au3Check + _WD_GetTable

### DIFF
--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -2893,7 +2893,7 @@ EndFunc   ;==>_WD_DispatchEvent
 ; ===============================================================================================================================
 Func _WD_GetTable($sSession, $sBaseElement, $sRowsSelector = Default, $sColsSelector = Default)
 	Local Const $sFuncName = "_WD_GetTable"
-	Local $aElements, $sElement, $iLines, $iRow, $iColumns, $iColumn, $sHTML, $aTable = ''
+	Local $sElement, $aTable = ''
 	$_WD_HTTPRESULT = 0
 	$_WD_HTTPRESPONSE = ''
 


### PR DESCRIPTION
## Pull request

### Proposed changes

This is fix for Au3Check `warning: .......: declared, but not used in func.`

### Checklist

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

- [ ] Bugfix (change which fixes an issue)
- [ ] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

Au3Check throws errors like `warning: $aElements: declared, but not used in func.`

### What is the new behavior?

no errors

### Additional context

none

### System under test

not related