### PR TITLE
Fixing names and $iErr usage

### DIFF
--- a/wd_capabilities.au3
+++ b/wd_capabilities.au3
@@ -297,10 +297,10 @@ Func _WD_CapabilitiesGet()
 	Local $Data1 = Json_Encode($_WD_CAPS__OBJECT)
 
 	Local $Data2 = Json_Decode($Data1)
-	Local $Json2 = Json_Encode($Data2, $Json_UNQUOTED_STRING)
+	Local $Json2 = Json_Encode($Data2, $JSON_UNQUOTED_STRING)
 
 	Local $Data3 = Json_Decode($Json2)
-	Local $Json3 = Json_Encode($Data3, $Json_PRETTY_PRINT, "    ", ",\n", ",\n", ":")
+	Local $Json3 = Json_Encode($Data3, $JSON_PRETTY_PRINT, "    ", ",\n", ",\n", ":")
 
 	If $Json3 = '' Or $Json3 = '""' Or Not IsString($Json3) Then $Json3 = $_WD_EmptyDict
 

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -692,7 +692,7 @@ Func _WD_GetFrameCount($sSession)
 	Local Const $sFuncName = "_WD_GetFrameCount"
 	Local $iValue = _WD_ExecuteScript($sSession, "return window.frames.length", Default, Default, $_WD_JSON_Value)
 	Local $iErr = @error
-	If @error Then $iValue = 0
+	If $iErr Then $iValue = 0
 	Return SetError(__WD_Error($sFuncName, $iErr), 0, Number($iValue))
 EndFunc   ;==>_WD_GetFrameCount
 
@@ -1984,7 +1984,7 @@ Func _WD_SelectFiles($sSession, $sStrategy, $sSelector, $sFilename)
 		If $iErr = $_WD_ERROR_Success Then
 			$sResult = _WD_ExecuteScript($sSession, "return arguments[0].files.length", __WD_JsonElement($sElement), Default, $_WD_JSON_Value)
 			$iErr = @error
-			If @error Then $sResult = "0"
+			If $iErr Then $sResult = "0"
 		EndIf
 	EndIf
 
@@ -2266,7 +2266,7 @@ Func _WD_GetBrowserVersion($sBrowser)
 	Local $sPath = _WD_GetBrowserPath($sBrowser)
 	$iErr = @error
 	$iExt = @extended
-	If @error Then
+	If $iErr Then
 		; as registry checks fails, now checking if file exist
 		If FileExists($sBrowser) Then
 			; Resetting as we are now checking file instead registry entries


### PR DESCRIPTION
## Pull request

### Proposed changes

proper $JSON_* names should be used
$iErr should be used in all places in the same way

### Checklist

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [ ] Bugfix (change which fixes an issue)
- [ ] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (functional, structural)
- [ ] Documentation content changes
- [x] Other (please describe)

### What is the current behavior?
unrelated to the intent of this PR

### What is the new behavior?
not changed

### Influences and relationship to other functionality
none

### Additional context
none

### System under test
not related
