### PR TITLE
_WD_GetBrowserPath and $_WD_ERROR_InvalidValue

### DIFF
--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -2308,7 +2308,6 @@ EndFunc   ;==>_WD_GetBrowserVersion
 ; Parameters ....: $sBrowser - Name of browser
 ; Return values .: Success - Full path to browser executable and sets @extended to index of $_WD_SupportedBrowsers
 ;                  Failure - "" and sets @error to one of the following values:
-;                  - $_WD_ERROR_InvalidValue
 ;                  - $_WD_ERROR_NotSupported
 ;                  - $_WD_ERROR_NotFound
 ; Author ........: Danp2


### PR DESCRIPTION
## Pull request

### Proposed changes

### Checklist

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes
- [ ] Bugfix (change which fixes an issue)
- [ ] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [x] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

`$_WD_ERROR_InvalidValue` in `_WD_GetBrowserPath` header 
but `_WD_GetBrowserPath` is not setting `$_WD_ERROR_InvalidValue`

### What is the new behavior?
`$_WD_ERROR_InvalidValue` removed from `_WD_GetBrowserPath` header


### Influences and relationship to other functionality
none

### Additional context

none

### System under test

not related