### PR TITLE
WinHttp.WinHttpRequest.5.1 usage

### DIFF
--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -2009,12 +2009,20 @@ EndFunc   ;==>_WD_SelectFiles
 ; ===============================================================================================================================
 Func _WD_IsLatestRelease()
 	Local Const $sFuncName = "_WD_IsLatestRelease"
-	Local Const $sGitURL = "https://github.com/Danp2/au3WebDriver/releases/latest"
+	Local Const $sURL = "https://github.com/Danp2/au3WebDriver/releases/latest"
 	Local $bResult = Null
 	Local $iErr = $_WD_ERROR_Success
 	Local $sRegex = '<a.*href="\/Danp2\/au3WebDriver\/releases\/tag\/(.*?)"'
 
-	Local $sResult = InetRead($sGitURL)
+	Local $sResult = InetRead($sURL)
+	If @error  Then
+		Local $oHTTP = ObjCreate("WinHttp.WinHttpRequest.5.1")
+		$oHTTP.Open("GET", $sURL, False)
+		$oHTTP.SetRequestHeader("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:121.0) Gecko/20100101 Firefox/121.0")
+		$oHTTP.Send("")
+		$sResult = $oHTTP.ResponseBody
+	EndIf
+
 	If @error Then $iErr = $_WD_ERROR_GeneralError
 
 	If $iErr = $_WD_ERROR_Success Then
@@ -2151,7 +2159,7 @@ Func _WD_UpdateDriver($sBrowser, $sInstallDir = Default, $bFlag64 = Default, $bF
 		$_WD_DEBUG = $WDDebugSave
 	EndIf
 
-	Local $sMessage = 'DriverCurrent = ' & $sDriverCurrent & ' : DriverLatest = ' & $sDriverLatest
+	Local $sMessage = 'DriverCurrent = ' & $sDriverCurrent & ' : DriverLatest = ' & $sDriverLatest & ' : $sInstallDir = ' & $sInstallDir
 	Return SetError(__WD_Error($sFuncName, $iErr, $sMessage, $iExt), $iExt, $bResult)
 EndFunc   ;==>_WD_UpdateDriver
 
@@ -2431,6 +2439,13 @@ Func _WD_DownloadFile($sURL, $sDest, $iOptions = Default)
 	If $iOptions = Default Then $iOptions = $INET_FORCERELOAD + $INET_IGNORESSL + $INET_BINARYTRANSFER
 
 	Local $sData = InetRead($sURL, $iOptions)
+	If @error Then
+		Local $oHTTP = ObjCreate("WinHttp.WinHttpRequest.5.1")
+		$oHTTP.Open("GET", $sURL, False)
+		$oHTTP.SetRequestHeader("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:121.0) Gecko/20100101 Firefox/121.0")
+		$oHTTP.Send("")
+		$sData = $oHTTP.ResponseBody
+	EndIf
 	If @error Then $iErr = $_WD_ERROR_NotFound
 
 	If $iErr = $_WD_ERROR_Success Then
@@ -3520,7 +3535,7 @@ EndFunc   ;==>__WD_JsonElement
 ; Return values .: Success - Array containing [0] URL for downloading requested webdriver & [1] matching webdriver version
 ;                  Failure - Empty array and sets @error to $_WD_ERROR_GeneralError
 ; Author ........: Danp2
-; Modified ......:
+; Modified ......: mLipok
 ; Remarks .......:
 ; Related .......:
 ; Link ..........:
@@ -3540,6 +3555,13 @@ Func __WD_GetLatestWebdriverInfo($aBrowser, $sBrowserVersion, $bFlag64)
 	EndIf
 
 	Local $sDriverLatest = InetRead($sURL)
+	If @error  Then
+		Local $oHTTP = ObjCreate("WinHttp.WinHttpRequest.5.1")
+		$oHTTP.Open("GET", $sURL, False)
+		$oHTTP.SetRequestHeader("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:121.0) Gecko/20100101 Firefox/121.0")
+		$oHTTP.Send("")
+		$sDriverLatest = $oHTTP.ResponseBody
+	EndIf
 
 	If @error = $_WD_ERROR_Success Then
 		Select


### PR DESCRIPTION
## Pull request

### Proposed changes

Today I hit a problem when trying to update geckodriver where InetRead() returns with error

### Checklist

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

- [x] Bugfix (change which fixes an issue)
- [ ] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

Sometimes InetRead and InetGet can return error thus there is no way to update driver with this udf.


### What is the new behavior?

when `InetRead` returns error then `WinHttp.WinHttpRequest.5.1` is used.

### Influences and relationship to other functionality

none

### Additional context

https://www.autoitscript.com/forum/topic/209621-inetget-alernative/
https://www.autoitscript.com/forum/topic/209610-inetget-dont-download-some-pages-since-ie11-is-no-longer-supported-by-some-sites
https://www.autoitscript.com/forum/topic/209472-download-problem-with-inetget/


### System under test

FireFox