### PR TITLE
_WD_UpdateDriver - desired BrowserVersion

### DIFF
--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -2035,12 +2035,13 @@ EndFunc   ;==>_WD_IsLatestRelease
 ; #FUNCTION# ====================================================================================================================
 ; Name ..........: _WD_UpdateDriver
 ; Description ...: Replace web driver with newer version, if available.
-; Syntax ........: _WD_UpdateDriver($sBrowser[, $sInstallDir = Default[, $bFlag64 = Default[, $bForce = Default[, $bDowngrade = Default]]]])
-; Parameters ....: $sBrowser    - Browser name or full path to browser executable
-;                  $sInstallDir - [optional] Install directory. Default is @ScriptDir
-;                  $bFlag64     - [optional] Install 64bit version? Default is current driver architecture or False
-;                  $bForce      - [optional] Force update? Default is False
-;                  $bDowngrade  - [optional] Downgrade to match browser version if needed? Default is False
+; Syntax ........: _WD_UpdateDriver($sBrowser[, $sInstallDir = Default[, $bFlag64 = Default[, $bForce = Default[, $bDowngrade = Default[, $sBrowserVersion = Default]]]]])
+; Parameters ....: $sBrowser        - Browser name or full path to browser executable
+;                  $sInstallDir     - [optional] Install directory. Default is @ScriptDir
+;                  $bFlag64         - [optional] Install 64bit version? Default is current driver architecture or False
+;                  $bForce          - [optional] Force update? Default is False
+;                  $bDowngrade      - [optional] Downgrade to match browser version if needed? Default is False
+;                  $sBrowserVersion - [optional] Force desired browser version
 ; Return values .: Success - True (Driver was updated).
 ;                  Failure - False (Driver was not updated) and sets @error to one of the following values:
 ;                  - $_WD_ERROR_FileIssue
@@ -2055,13 +2056,14 @@ EndFunc   ;==>_WD_IsLatestRelease
 ; Remarks .......: When $bForce = Null, then the function will check for an updated webdriver without actually performing the update.
 ;                  This can be used in conjunction with $bDowngrade to determine if the existing webdriver is too new for the browser.
 ;                  In this scenario, the return value indicates if an update / downgrade is available.
+;                  Using $sBrowserVersion you can provide desired browser version from computer not connected to internet saved earlier by _WD_GetBrowserVersion()
 ; Related .......: _WD_GetBrowserVersion, _WD_GetWebDriverVersion
 ; Link ..........:
 ; Example .......: Local $bResult = _WD_UpdateDriver('FireFox')
 ; ===============================================================================================================================
-Func _WD_UpdateDriver($sBrowser, $sInstallDir = Default, $bFlag64 = Default, $bForce = Default, $bDowngrade = Default)
+Func _WD_UpdateDriver($sBrowser, $sInstallDir = Default, $bFlag64 = Default, $bForce = Default, $bDowngrade = Default, $sBrowserVersion = Default)
 	Local Const $sFuncName = "_WD_UpdateDriver"
-	Local $iErr = $_WD_ERROR_Success, $iExt = 0, $sDriverEXE, $sBrowserVersion, $bResult = False
+	Local $iErr = $_WD_ERROR_Success, $iExt = 0, $sDriverEXE, $bResult = False
 	Local $sDriverCurrent, $sDriverLatest, $sURLNewDriver
 	Local $sTempFile
 	Local $bKeepArch = False
@@ -2085,9 +2087,11 @@ Func _WD_UpdateDriver($sBrowser, $sInstallDir = Default, $bFlag64 = Default, $bF
 		Local $WDDebugSave = $_WD_DEBUG
 		If $_WD_DEBUG <> $_WD_DEBUG_Full Then $_WD_DEBUG = $_WD_DEBUG_None
 
-		$sBrowserVersion = _WD_GetBrowserVersion($sBrowser)
-		$iErr = @error
-		$iExt = @extended
+		If $sBrowserVersion = Default then
+			$sBrowserVersion = _WD_GetBrowserVersion($sBrowser)
+			$iErr = @error
+			$iExt = @extended
+		EndIf
 
 		If $iErr = $_WD_ERROR_Success Then
 			Local $iIndex = @extended
@@ -2151,7 +2155,7 @@ Func _WD_UpdateDriver($sBrowser, $sInstallDir = Default, $bFlag64 = Default, $bF
 		$_WD_DEBUG = $WDDebugSave
 	EndIf
 
-	Local $sMessage = 'DriverCurrent = ' & $sDriverCurrent & ' : DriverLatest = ' & $sDriverLatest
+	Local $sMessage = 'DriverCurrent = ' & $sDriverCurrent & ' : DriverLatest = ' & $sDriverLatest & ' : $sInstallDir = ' & $sInstallDir
 	Return SetError(__WD_Error($sFuncName, $iErr, $sMessage, $iExt), $iExt, $bResult)
 EndFunc   ;==>_WD_UpdateDriver
 


### PR DESCRIPTION
## Pull request

### Proposed changes

User should be able to provide specific/desired browser version to download/update desired driver

### Checklist

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [ ] Bugfix (change which fixes an issue)
- [X] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

computer station should be connected to internet to be able to get driver related to current computer station

### What is the new behavior?

you can check browser version computer only with INTRANET (not connected to internet) store them for example to INI file, 
and downlad the desired driver on different computer

### Influences and relationship to other functionality
none

### Additional context
https://www.autoitscript.com/forum/topic/210991-webdriver-_wd_updatedriverfirefox-dont-work-on-intranet

https://www.autoitscript.com/forum/topic/210991-webdriver-_wd_updatedriverfirefox-dont-work-on-intranet/?do=findComment&comment=1525803


### System under test
not related
