### PR TITLE
Update wd_demo.au3 - DriverParams direct port definition

### DIFF
--- a/wd_demo.au3
+++ b/wd_demo.au3
@@ -1236,7 +1236,7 @@ EndFunc   ;==>SetupGecko
 Func SetupChrome($bHeadless)
 	_WD_Option('Driver', 'chromedriver.exe')
 	_WD_Option('Port', 9515)
-	_WD_Option('DriverParams', '--verbose --log-path="' & @ScriptDir & '\chrome.log"')
+	_WD_Option('DriverParams', '--port=9515 --verbose --log-path="' & @ScriptDir & '\chrome.log"')
 
 ;~ 	Local $sCapabilities = '{"capabilities": {"alwaysMatch": {"goog:chromeOptions": {"w3c": true, "excludeSwitches": [ "enable-automation"]}}}}'
 	_WD_CapabilitiesStartup()
@@ -1252,7 +1252,7 @@ EndFunc   ;==>SetupChrome
 Func SetupEdge($bHeadless)
 	_WD_Option('Driver', 'msedgedriver.exe')
 	_WD_Option('Port', 9515)
-	_WD_Option('DriverParams', '--verbose --log-path="' & @ScriptDir & '\msedge.log"')
+	_WD_Option('DriverParams', '--port=9515 --verbose --log-path="' & @ScriptDir & '\msedge.log"')
 
 ;~ 	Local $sCapabilities = '{"capabilities": {"alwaysMatch": {"ms:edgeOptions": {"excludeSwitches": [ "enable-automation"]}}}}'
 	_WD_CapabilitiesStartup()
@@ -1267,7 +1267,7 @@ EndFunc   ;==>SetupEdge
 Func SetupOpera($bHeadless)
 	_WD_Option('Driver', 'operadriver.exe')
 	_WD_Option('Port', 9515)
-	_WD_Option('DriverParams', '--verbose --log-path="' & @ScriptDir & '\opera.log"')
+	_WD_Option('DriverParams', '--port=9515 --verbose --log-path="' & @ScriptDir & '\opera.log"')
 
 ;~ 	Local $sCapabilities = '{"capabilities": {"alwaysMatch":{"goog:chromeOptions": {"w3c":true, "excludeSwitches":["enable-automation"], "binary":"C:\\Users\\......\\AppData\\Local\\Programs\\Opera\\opera.exe"}}}}'
 	_WD_CapabilitiesStartup()
@@ -1297,7 +1297,7 @@ Func SetupEdgeIEMode() ; this is for MS Edge IE Mode
 	Local $iPort = _WD_GetFreePort(5555, 5600)
 	If @error Then Return SetError(@error, @extended, 0)
 	_WD_Option('Port', $iPort)
-	_WD_Option('DriverParams', '-log-file="' & @ScriptDir & '\log\' & $sTimeStamp & '_WebDriver_EdgeIEMode.log" -log-level=INFO' & " -port=" & $_WD_PORT & " -host=127.0.0.1")
+	_WD_Option('DriverParams', '--port=' & $iPort & ' -log-file="' & @ScriptDir & '\log\' & $sTimeStamp & '_WebDriver_EdgeIEMode.log" -log-level=INFO' & " -port=" & $_WD_PORT & " -host=127.0.0.1")
 
 ;~ 	Local $sCapabilities = '{"capabilities": {"alwaysMatch": { "se:ieOptions" : { "ie.edgepath":"C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe", "ie.edgechromium":true, "ignoreProtectedModeSettings":true,"excludeSwitches": ["enable-automation"]}}}}'
 	_WD_CapabilitiesStartup()

--- a/wd_demo.au3
+++ b/wd_demo.au3
@@ -1213,7 +1213,7 @@ Func SetupGecko($bHeadless)
 	If @error Then Return SetError(@error, @extended, 0)
 
 	_WD_Option('Port', $iPort)
-	_WD_Option('DriverParams', '--port=' & $iPort)
+	_WD_Option('DriverParams', '--port=' & $iPort & ' --log trace')
 
 ;~ 	Local $sCapabilities = '{"capabilities": {"alwaysMatch": {"browserName": "firefox", "acceptInsecureCerts":true}}}'
 	_WD_CapabilitiesStartup()

--- a/wd_demo.au3
+++ b/wd_demo.au3
@@ -1209,8 +1209,12 @@ EndFunc   ;==>_Demo_NavigateCheckBanner
 
 Func SetupGecko($bHeadless)
 	_WD_Option('Driver', 'geckodriver.exe')
-	_WD_Option('DriverParams', '--log trace')
-	_WD_Option('Port', 4444)
+	Local $iPort = _WD_GetFreePort(4444)
+	If @error Then Return SetError(@error, @extended, 0)
+
+	_WD_Option('Port', $iPort)
+	_WD_Option('DriverParams', '--port=' & $_WD_PORT)
+;~ 	_WD_Option('DriverParams', '--port=' & $_WD_PORT & ' --verbose --log-path="' & @ScriptDir & '\gecko.log"')
 
 ;~ 	Local $sCapabilities = '{"capabilities": {"alwaysMatch": {"browserName": "firefox", "acceptInsecureCerts":true}}}'
 	_WD_CapabilitiesStartup()
@@ -1235,8 +1239,11 @@ EndFunc   ;==>SetupGecko
 
 Func SetupChrome($bHeadless)
 	_WD_Option('Driver', 'chromedriver.exe')
-	_WD_Option('Port', 9515)
-	_WD_Option('DriverParams', '--port=9515 --verbose --log-path="' & @ScriptDir & '\chrome.log"')
+	Local $iPort = _WD_GetFreePort(5555, 5600)
+	If @error Then Return SetError(@error, @extended, 0)
+
+	_WD_Option('Port', $iPort)
+	_WD_Option('DriverParams', '--port=' & $_WD_PORT & ' --verbose --log-path="' & @ScriptDir & '\chrome.log"')
 
 ;~ 	Local $sCapabilities = '{"capabilities": {"alwaysMatch": {"goog:chromeOptions": {"w3c": true, "excludeSwitches": [ "enable-automation"]}}}}'
 	_WD_CapabilitiesStartup()
@@ -1251,8 +1258,11 @@ EndFunc   ;==>SetupChrome
 
 Func SetupEdge($bHeadless)
 	_WD_Option('Driver', 'msedgedriver.exe')
-	_WD_Option('Port', 9515)
-	_WD_Option('DriverParams', '--port=9515 --verbose --log-path="' & @ScriptDir & '\msedge.log"')
+	Local $iPort = _WD_GetFreePort(9515)
+	If @error Then Return SetError(@error, @extended, 0)
+
+	_WD_Option('Port', $iPort)
+	_WD_Option('DriverParams', '--port=' & $_WD_PORT & ' --verbose --log-path="' & @ScriptDir & '\msedge.log"')
 
 ;~ 	Local $sCapabilities = '{"capabilities": {"alwaysMatch": {"ms:edgeOptions": {"excludeSwitches": [ "enable-automation"]}}}}'
 	_WD_CapabilitiesStartup()
@@ -1266,8 +1276,11 @@ EndFunc   ;==>SetupEdge
 
 Func SetupOpera($bHeadless)
 	_WD_Option('Driver', 'operadriver.exe')
-	_WD_Option('Port', 9515)
-	_WD_Option('DriverParams', '--port=9515 --verbose --log-path="' & @ScriptDir & '\opera.log"')
+	Local $iPort = _WD_GetFreePort(9515)
+	If @error Then Return SetError(@error, @extended, 0)
+
+	_WD_Option('Port', $iPort)
+	_WD_Option('DriverParams', '--port=' & $_WD_PORT & ' --verbose --log-path="' & @ScriptDir & '\opera.log"')
 
 ;~ 	Local $sCapabilities = '{"capabilities": {"alwaysMatch":{"goog:chromeOptions": {"w3c":true, "excludeSwitches":["enable-automation"], "binary":"C:\\Users\\......\\AppData\\Local\\Programs\\Opera\\opera.exe"}}}}'
 	_WD_CapabilitiesStartup()
@@ -1296,8 +1309,9 @@ Func SetupEdgeIEMode() ; this is for MS Edge IE Mode
 	_WD_Option('Driver', 'IEDriverServer.exe') ;
 	Local $iPort = _WD_GetFreePort(5555, 5600)
 	If @error Then Return SetError(@error, @extended, 0)
+
 	_WD_Option('Port', $iPort)
-	_WD_Option('DriverParams', '--port=' & $iPort & ' -log-file="' & @ScriptDir & '\log\' & $sTimeStamp & '_WebDriver_EdgeIEMode.log" -log-level=INFO' & " -port=" & $_WD_PORT & " -host=127.0.0.1")
+	_WD_Option('DriverParams', '--port=' & $_WD_PORT & ' -log-file="' & @ScriptDir & '\log\' & $sTimeStamp & '_WebDriver_EdgeIEMode.log" -log-level=INFO' & " -port=" & $_WD_PORT & " -host=127.0.0.1")
 
 ;~ 	Local $sCapabilities = '{"capabilities": {"alwaysMatch": { "se:ieOptions" : { "ie.edgepath":"C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe", "ie.edgechromium":true, "ignoreProtectedModeSettings":true,"excludeSwitches": ["enable-automation"]}}}}'
 	_WD_CapabilitiesStartup()

--- a/wd_demo.au3
+++ b/wd_demo.au3
@@ -1209,12 +1209,11 @@ EndFunc   ;==>_Demo_NavigateCheckBanner
 
 Func SetupGecko($bHeadless)
 	_WD_Option('Driver', 'geckodriver.exe')
-	Local $iPort = _WD_GetFreePort(4444)
+	Local $iPort = _WD_GetFreePort(4444, 4500)
 	If @error Then Return SetError(@error, @extended, 0)
 
 	_WD_Option('Port', $iPort)
-	_WD_Option('DriverParams', '--port=' & $_WD_PORT)
-;~ 	_WD_Option('DriverParams', '--port=' & $_WD_PORT & ' --verbose --log-path="' & @ScriptDir & '\gecko.log"')
+	_WD_Option('DriverParams', '--port=' & $iPort)
 
 ;~ 	Local $sCapabilities = '{"capabilities": {"alwaysMatch": {"browserName": "firefox", "acceptInsecureCerts":true}}}'
 	_WD_CapabilitiesStartup()
@@ -1243,7 +1242,7 @@ Func SetupChrome($bHeadless)
 	If @error Then Return SetError(@error, @extended, 0)
 
 	_WD_Option('Port', $iPort)
-	_WD_Option('DriverParams', '--port=' & $_WD_PORT & ' --verbose --log-path="' & @ScriptDir & '\chrome.log"')
+	_WD_Option('DriverParams', '--port=' & $iPort & ' --verbose --log-path="' & @ScriptDir & '\chrome.log"')
 
 ;~ 	Local $sCapabilities = '{"capabilities": {"alwaysMatch": {"goog:chromeOptions": {"w3c": true, "excludeSwitches": [ "enable-automation"]}}}}'
 	_WD_CapabilitiesStartup()
@@ -1258,11 +1257,11 @@ EndFunc   ;==>SetupChrome
 
 Func SetupEdge($bHeadless)
 	_WD_Option('Driver', 'msedgedriver.exe')
-	Local $iPort = _WD_GetFreePort(9515)
+	Local $iPort = _WD_GetFreePort(9515, 9600)
 	If @error Then Return SetError(@error, @extended, 0)
 
 	_WD_Option('Port', $iPort)
-	_WD_Option('DriverParams', '--port=' & $_WD_PORT & ' --verbose --log-path="' & @ScriptDir & '\msedge.log"')
+	_WD_Option('DriverParams', '--port=' & $iPort & ' --verbose --log-path="' & @ScriptDir & '\msedge.log"')
 
 ;~ 	Local $sCapabilities = '{"capabilities": {"alwaysMatch": {"ms:edgeOptions": {"excludeSwitches": [ "enable-automation"]}}}}'
 	_WD_CapabilitiesStartup()
@@ -1276,11 +1275,11 @@ EndFunc   ;==>SetupEdge
 
 Func SetupOpera($bHeadless)
 	_WD_Option('Driver', 'operadriver.exe')
-	Local $iPort = _WD_GetFreePort(9515)
+	Local $iPort = _WD_GetFreePort(9515, 9600)
 	If @error Then Return SetError(@error, @extended, 0)
 
 	_WD_Option('Port', $iPort)
-	_WD_Option('DriverParams', '--port=' & $_WD_PORT & ' --verbose --log-path="' & @ScriptDir & '\opera.log"')
+	_WD_Option('DriverParams', '--port=' & $iPort & ' --verbose --log-path="' & @ScriptDir & '\opera.log"')
 
 ;~ 	Local $sCapabilities = '{"capabilities": {"alwaysMatch":{"goog:chromeOptions": {"w3c":true, "excludeSwitches":["enable-automation"], "binary":"C:\\Users\\......\\AppData\\Local\\Programs\\Opera\\opera.exe"}}}}'
 	_WD_CapabilitiesStartup()
@@ -1311,7 +1310,7 @@ Func SetupEdgeIEMode() ; this is for MS Edge IE Mode
 	If @error Then Return SetError(@error, @extended, 0)
 
 	_WD_Option('Port', $iPort)
-	_WD_Option('DriverParams', '--port=' & $_WD_PORT & ' -log-file="' & @ScriptDir & '\log\' & $sTimeStamp & '_WebDriver_EdgeIEMode.log" -log-level=INFO' & " -port=" & $_WD_PORT & " -host=127.0.0.1")
+	_WD_Option('DriverParams', '--port=' & $iPort & ' -log-file="' & @ScriptDir & '\log\' & $sTimeStamp & '_WebDriver_EdgeIEMode.log" -log-level=INFO' & " -port=" & $iPort & " -host=127.0.0.1")
 
 ;~ 	Local $sCapabilities = '{"capabilities": {"alwaysMatch": { "se:ieOptions" : { "ie.edgepath":"C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe", "ie.edgechromium":true, "ignoreProtectedModeSettings":true,"excludeSwitches": ["enable-automation"]}}}}'
 	_WD_CapabilitiesStartup()

--- a/wd_demo.au3
+++ b/wd_demo.au3
@@ -1310,7 +1310,7 @@ Func SetupEdgeIEMode() ; this is for MS Edge IE Mode
 	If @error Then Return SetError(@error, @extended, 0)
 
 	_WD_Option('Port', $iPort)
-	_WD_Option('DriverParams', '--port=' & $iPort & ' -log-file="' & @ScriptDir & '\log\' & $sTimeStamp & '_WebDriver_EdgeIEMode.log" -log-level=INFO' & " -port=" & $iPort & " -host=127.0.0.1")
+	_WD_Option('DriverParams', '--port=' & $iPort & " -host=127.0.0.1" & ' -log-file="' & @ScriptDir & '\log\' & $sTimeStamp & '_WebDriver_EdgeIEMode.log" -log-level=INFO')
 
 ;~ 	Local $sCapabilities = '{"capabilities": {"alwaysMatch": { "se:ieOptions" : { "ie.edgepath":"C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe", "ie.edgechromium":true, "ignoreProtectedModeSettings":true,"excludeSwitches": ["enable-automation"]}}}}'
 	_WD_CapabilitiesStartup()


### PR DESCRIPTION
## Pull request

### Proposed changes

Port should be direct defined in DriverParams

### Checklist

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

- [x] Bugfix (change which fixes an issue)
- [ ] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

chomium based browser not starting

### What is the new behavior?

now its starts properly

### Influences and relationship to other functionality

none

### Additional context

https://www.autoitscript.com/forum/topic/212201-chromedriver-issues-august-2024
https://chromium.googlesource.com/chromium/src/+/6f33d75f071e322c4a3e49b0a4ac2022e5b6cada

### System under test

MSEdge, Chrome

