### PR TITLE
_WD_GetTable - Use innerText instead of textContent

### DIFF
--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -2913,7 +2913,7 @@ Func _WD_GetTable($sSession, $sStrategy, $sSelector, $sRowsSelector = Default, $
 		; https://stackoverflow.com/questions/64842157
 		Local $sScript = "return [...arguments[0].querySelectorAll(arguments[1])]" & _
 				".map(row => [...row.querySelectorAll(arguments[2])]" & _
-				".map(cell => cell.textContent));"
+				".map(cell => cell.innerText));"
 		Local $sArgs = __WD_JsonElement($sElement) & ', "' & $sRowsSelector & '", "' & $sColsSelector & '"'
 		Local $sResult = _WD_ExecuteScript($sSession, $sScript, $sArgs)
 		$iErr = @error


### PR DESCRIPTION
Signed-off-by: Dan Pollak <danpollak2@gmail.com>

## Pull request

### Proposed changes

Use innerText instead of textContent when retrieving cell contents of table

### Checklist

Put an `x` in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We are here to help!<br>
This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [x] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [x] Bugfix (change which fixes an issue)
- [ ] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

Test can contain formatting such as \t and \n

### What is the new behavior?

No formatting is returned

### Influences and relationship to other functionality

Describe how the changes will affect other functions, potential script breaking changes, etc.

### Additional context

https://www.autoitscript.com/forum/topic/212230-whitespace-characters-showing-when-accessing-a-table-using-_wd_gettable

### System under test

Please complete the following information.

- OS: [e.g. Windows 10]
- OS Arch.: [e.g. X64]
- Browser [e.g. firefox]
- Browser version [e.g. 96.0.3]

