### PR TITLE
_WD_JsonActionKey: Don't encode Unicode characters

### DIFF
--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -3221,6 +3221,12 @@ Func _WD_JsonActionKey($sType, $sKey, $iSuffix = Default)
 	Json_Put($vData, '.actions[0].type', $sType)
 	Json_Put($vData, '.actions[0].value', $sKey)
 	Local $sJSON = Json_Encode($vData)
+
+	; Don't encode backslash of Unicode character
+	If StringLeft($sKey,2) = '\u' Then
+		$sJSON = StringReplace($sJSON, "\\u", "\u")
+	EndIf
+
 	Return SetError(__WD_Error($sFuncName, 0, $sJSON), 0, $sJSON)
 EndFunc   ;==>_WD_JsonActionKey
 


### PR DESCRIPTION
## Pull request

### Proposed changes

Don't encode the backslash character when unicode character is used with _WD_JsonActionKey

### Checklist

Put an `x` in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We are here to help!<br>
This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [x] Bugfix (change which fixes an issue)
- [ ] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

Unicode characters are encoded so that they begin with a double backslash

### What is the new behavior?

Check for unicode character and prevent double backslash

### Influences and relationship to other functionality


### Additional context

https://www.autoitscript.com/forum/topic/212262-webdriver-udf-_wd_elementactionex-reports-errors-when-trying-to-use-command-modifierclick/

### System under test

Please complete the following information.

- OS: [e.g. Windows 10]
- OS Arch.: [e.g. X64]
- Browser [e.g. firefox]
- Browser version [e.g. 96.0.3]

Signed-off-by: Dan Pollak <danpollak2@gmail.com>
