### PR TITLE
Fix: Ensure InetRead usage isn't using local cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Go to [legend](#legend---types-of-changes) for further information about the types of changes.
 
+## [Unreleased]
+
+### Changed
+
+- Use $INET_FORCERELOAD with InetRead (_WD_IsLatestRelease & __WD_GetLatestWebdriverInfo)
+
 ## [1.4.0] 2024-09-21
 
 ### Changed

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -2014,7 +2014,7 @@ Func _WD_IsLatestRelease()
 	Local $iErr = $_WD_ERROR_Success
 	Local $sRegex = '<a.*href="\/Danp2\/au3WebDriver\/releases\/tag\/(.*?)"'
 
-	Local $sResult = InetRead($sGitURL)
+	Local $sResult = InetRead($sGitURL, $INET_FORCERELOAD)
 	If @error Then $iErr = $_WD_ERROR_GeneralError
 
 	If $iErr = $_WD_ERROR_Success Then
@@ -3548,7 +3548,7 @@ Func __WD_GetLatestWebdriverInfo($aBrowser, $sBrowserVersion, $bFlag64)
 		$sURL = Execute($sURL)
 	EndIf
 
-	Local $sDriverLatest = InetRead($sURL)
+	Local $sDriverLatest = InetRead($sURL, $INET_FORCERELOAD)
 
 	If @error = $_WD_ERROR_Success Then
 		Select


### PR DESCRIPTION
## Pull request

### Proposed changes

Enforce usage of $INET_FORCERELOAD with InetRead

### Checklist

Put an `x` in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We are here to help!<br>
This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [x] Bugfix (change which fixes an issue)
- [ ] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

InetRead defaults to retrieving the file from the local cache

### What is the new behavior?

Forces a reload from the remote site

### Influences and relationship to other functionality

Affects _WD_IsLatestRelease & __WD_GetLatestWebdriverInfo

### Additional context

Fixes #527 

### System under test

Please complete the following information.

- OS: [e.g. Windows 10]
- OS Arch.: [e.g. X64]
- Browser [e.g. firefox]
- Browser version [e.g. 96.0.3]

Signed-off-by: Dan Pollak <danpollak2@gmail.com>