### PR TITLE
_WD_CapabilitiesAdd - IsBool($value1) - IsBool($value2)

### DIFF
--- a/wd_capabilities.au3
+++ b/wd_capabilities.au3
@@ -175,6 +175,8 @@ Func _WD_CapabilitiesAdd($key, $value1 = Default, $value2 = Default)
 
 	If $value1 = Default Then $value1 = ''
 	If $value2 = Default Then $value2 = ''
+	If IsBool($value1) Then $value1 = StringLower($value1)
+	If IsBool($value2) Then $value2 = StringLower($value2)
 	Local Const $s_Parameters_Info = '     $key = ' & $key & '     $value1 = ' & $value1 & '     $value2 = ' & $value2
 	__WD_ConsoleWrite($sFuncName & ': #' & @ScriptLineNumber & ' : ' & $s_Parameters_Info, $_WD_DEBUG_Full)
 
@@ -277,7 +279,7 @@ Func _WD_CapabilitiesAdd($key, $value1 = Default, $value2 = Default)
 	__WD_ConsoleWrite($sFuncName & ": #" & $v_WatchPoint & ' #' & @ScriptLineNumber & ' : ' & $s_Parameters_Info & '    $s_Notation = ' & $s_Notation & '   <<<<  ' & $value1, $_WD_DEBUG_Full)
 	If @error Then Return SetError(__WD_Error($sFuncName, $_WD_ERROR_GeneralError, $s_Parameters_Info))
 	Json_Put($_WD_CAPS__OBJECT, $s_Notation, $value1)
-	Return SetError(__WD_Error($sFuncName, $_WD_ERROR_Success, 'Successfully added capability'))
+	Return SetError(__WD_Error($sFuncName, $_WD_ERROR_Success, 'Successfully added capability: ' & $s_Parameters_Info))
 EndFunc   ;==>_WD_CapabilitiesAdd
 
 ; #FUNCTION# ====================================================================================================================


### PR DESCRIPTION
## Pull request

### Proposed changes

When adding capability where value are Booleans they should be changed to lower string

### Checklist

Put an `x` in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We are here to help!<br>
This is simply a reminder of what we are going to look for before merging your code.

- [X] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [X] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [X] Bugfix (change which fixes an issue)
- [ ] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?
using:
```autoit
_WD_CapabilitiesDefine($_WD_KEYS__SPECIFICVENDOR_PRIMITIVE, 'useAutomationExtension')
_WD_CapabilitiesAdd('useAutomationExtension', False)
_WD_CapabilitiesDump(@ScriptLineNumber)
```
will delete previously added capabilities

### What is the new behavior?

works fine

### Influences and relationship to other functionality

none

### Additional context

https://github.com/Danp2/au3WebDriver/issues/531#issuecomment-3078574958

testing script:
https://github.com/Danp2/au3WebDriver/issues/531#issuecomment-3078580703

This issue can be deeply analyzed with this following modification:
```autoit
	ElseIf StringRegExp($key, $_WD_KEYS__SPECIFICVENDOR_PRIMITIVE, $STR_REGEXPMATCH) And $_WD_NOTATION__SPECIFICVENDOR <> '' Then ; add "JSON_BOOLEAN" value type in SPECIFIC/VENDOR part of Capabilities JSON Structure
		$v_WatchPoint = @ScriptLineNumber
		$s_Notation = $_WD_NOTATION__MATCHTYPE & $_WD_NOTATION__SPECIFICVENDOR
		If $value1 == False Or $value1 == StringLower(False) Then MsgBox($MB_TOPMOST, "TEST #" & @ScriptLineNumber, $s_Notation)
		If $value1 <> '' Then $s_Notation &= '["' & $key & '"]'
		If $value1 == False Or $value1 == StringLower(False) Then MsgBox($MB_TOPMOST, "TEST #" & @ScriptLineNumber, $s_Notation)
```

When `$value1` is `False` boolean value,  this following line:
```autoit
If $value1 <> '' Then $s_Notation &= '["' & $key & '"]'
```
is skiped.


### System under test

not releated to system or browser, just capabilities UDF have some issues.
